### PR TITLE
Add an http healthcheck for the worker service

### DIFF
--- a/apps/worker/src/createHealthcheck.ts
+++ b/apps/worker/src/createHealthcheck.ts
@@ -1,0 +1,22 @@
+import { env } from "@playfulprogramming/common";
+import http from "http";
+import { healthcheckRedis } from "@playfulprogramming/redis";
+import { healthcheckPostgres } from "@playfulprogramming/db";
+
+export function createHealthcheck() {
+	const server = http.createServer(async (_, res) => {
+		try {
+			await Promise.all([healthcheckRedis(), healthcheckPostgres()]);
+			console.log("Healthcheck success!");
+			res.writeHead(200);
+			res.end("OK");
+		} catch (e) {
+			console.error("Error during healthcheck:", e);
+			res.writeHead(500);
+			res.end();
+		}
+	});
+
+	server.listen(env.WORKER_PORT);
+	console.log("Listening for healthcheck on port", env.WORKER_PORT);
+}

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,5 +1,7 @@
+import { createHealthcheck } from "./createHealthcheck.ts";
 import { createWorker } from "./createWorker.ts";
 import { Tasks } from "@playfulprogramming/common";
 
 createWorker(Tasks.POST_IMAGES, "./tasks/post-images/processor.ts");
 createWorker(Tasks.URL_METADATA, "./tasks/url-metadata/processor.ts");
+createHealthcheck();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
     depends_on: [pgsql, redis, minio]
     profiles: [app]
     healthcheck:
-      test: wget --no-verbose --tries=1 --spider http://localhost:3000 || exit 1
+      test: wget --no-verbose --tries=1 --spider http://0.0.0.0:3000 && wget --no-verbose --tries=1 --spider http://0.0.0.0:3001 || exit 1
       interval: 10s
       timeout: 5s
       retries: 5

--- a/fly.toml
+++ b/fly.toml
@@ -13,6 +13,7 @@ primary_region = 'ewr'
 
 [env]
   PORT = "8080"
+  WORKER_PORT = "8081"
   ENVIRONMENT = "production"
   SITE_URL = "https://playfulprogramming.com"
   S3_PUBLIC_URL = "https://fly.storage.tigris.dev"
@@ -48,6 +49,17 @@ primary_region = 'ewr'
     method = "GET"
     timeout = "10s"
     path = "/health/postgres"
+
+[checks]
+  [checks.worker_http]
+    type = "http"
+    grace_period = "10s"
+    interval = "30s"
+    method = "GET"
+    timeout = "5s"
+    path = "/"
+    port = 8081
+    processes = ['worker']
 
 
 [[vm]]

--- a/packages/common/src/env.ts
+++ b/packages/common/src/env.ts
@@ -3,6 +3,7 @@ import { Value } from "@sinclair/typebox/value";
 
 export const EnvSchema = Type.Object({
 	PORT: Type.Integer({ default: 3000 }),
+	WORKER_PORT: Type.Integer({ default: 3001 }),
 	ENVIRONMENT: Type.Union([
 		Type.Literal("development"),
 		Type.Literal("production"),


### PR DESCRIPTION
This should avoid issues where the worker stalls / runs out of memory and cannot handle any tasks.