### PR TITLE
Add minimum release age configuration to pnpm-workspace.yaml

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,3 +25,5 @@ onlyBuiltDependencies:
   - msw
   - nx
   - sharp
+
+minimumReleaseAge: 10080 # 7 days


### PR DESCRIPTION
Applies the issue https://github.com/playfulprogramming/playfulprogramming/issues/1605 like the PR https://github.com/playfulprogramming/playfulprogramming/pull/1607 as `7 days`.

The `dependabot` already configured to wait for minimum `14 days`.
https://github.com/playfulprogramming/hoof/blob/0e2ae619241007096f44a227274c44ac7a0c7b0f/.github/dependabot.yml#L7-L8

That is already a good guard for automatic updates but it is still good to have an extra guard for a possible case of a manual update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release configuration in workspace settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->