### PR TITLE
feat: add author achievements system

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,7 @@ HOOF_AUTH_TOKEN=supersecret
 RATE_LIMIT_MAX=10000
 RATE_LIMIT_WINDOW="10 minutes"
 RATE_LIMIT_BAN_THRESHOLD=10
+
+# Optional. Only needed for GitHub-based achievement calculation (issue/PR/commit stats).
+# Generate one at github.com/settings/tokens with public repo read access.
+GITHUB_TOKEN=

--- a/apps/api/src/createApp.ts
+++ b/apps/api/src/createApp.ts
@@ -5,6 +5,7 @@ import swagger from "./plugins/swagger.ts";
 import { healthRoutes } from "./routes/health.ts";
 import postImagesRoutes from "./routes/tasks/post-images.ts";
 import urlMetadataRoutes from "./routes/tasks/url-metadata.ts";
+import authorsRoutes from "./routes/content/authors.ts";
 import collectionsRoutes from "./routes/content/collections.ts";
 import fastify from "fastify";
 import devRoutes from "./routes/dev/index.ts";
@@ -20,6 +21,7 @@ export const createApp = () => {
 	app.register(healthRoutes);
 	app.register(postImagesRoutes);
 	app.register(urlMetadataRoutes);
+	app.register(authorsRoutes);
 	app.register(collectionsRoutes);
 
 	if (env.ENVIRONMENT === "development") {

--- a/apps/api/src/routes/content/authors.ts
+++ b/apps/api/src/routes/content/authors.ts
@@ -1,0 +1,247 @@
+import type { FastifyPluginAsync } from "fastify";
+import { db, postAuthors, postData } from "@playfulprogramming/db";
+import { Type, type Static } from "typebox";
+import { and, eq, sum } from "drizzle-orm";
+import { createImageUrl } from "../../utils.ts";
+
+// ── Achievement display map ────────────────────────────────────────────────────
+
+type AchievementDisplay = { name: string; body: string };
+
+const FIXED_ACHIEVEMENT_DISPLAY: Record<string, AchievementDisplay> = {
+	// Manual
+	"site-redesign": { name: "Redesign Ruler", body: "Led a site-wide redesign" },
+	"site-logo": { name: "Logo Legacy", body: "Made our Unicorn logo!" },
+	"code-challenge": {
+		name: "Code Challenger",
+		body: "Make a code challenge in our Discord",
+	},
+	partner: {
+		name: "Proud partner",
+		body: "Become a Playful Programming Partner",
+	},
+	"messages-200": {
+		name: "Moderate Messager",
+		body: "Send 200 messages in our Discord",
+	},
+	"messages-500": {
+		name: "Monstrous Messager",
+		body: "Send 500 messages in our Discord",
+	},
+	"messages-1000": {
+		name: "Message Madness",
+		body: "Send 1000 messages in our Discord",
+	},
+	// Role-based
+	"hello-world": { name: "Hello, World!", body: "Earn your first role badge" },
+	"badge-collector": {
+		name: "Badge Collector",
+		body: "Have at least 3 role badges",
+	},
+	"localizer-9000": {
+		name: "Localizer 9000",
+		body: "Translate part of Playful Programming into another language!",
+	},
+	"community-crowned": {
+		name: "Community crowned",
+		body: "Become a community leader",
+	},
+	// Content-based
+	"words-words-words": {
+		name: "Words words words",
+		body: "", // body is computed dynamically from total word count
+	},
+	"it-keeps-going": {
+		name: "It Keeps Going",
+		body: "Write a really long article",
+	},
+	"politely-posting": { name: "Politely Posting", body: "Write 3 articles!" },
+	"profusely-posting": {
+		name: "Profusely Posting",
+		body: "Write 5 articles!",
+	},
+	"post-palooza": { name: "Post-palooza", body: "Write 10 articles!" },
+	"cream-of-the-crop": {
+		name: "Cream of the crop",
+		body: "Write 30 articles!",
+	},
+	"team-player": {
+		name: "Team Player",
+		body: "Collaborate on an article with another author",
+	},
+	"collect-em-all": {
+		name: "Collect 'em all",
+		body: "Author a collection of posts!",
+	},
+	// GitHub-based — issues
+	bug: { name: "Bug!", body: "Open an issue in our GitHub repo" },
+	"creepy-crawlies": {
+		name: "Creepy crawlies!",
+		body: "Open 10 issues in our GitHub repo",
+	},
+	"insect-infestation": {
+		name: "Insect infestation!",
+		body: "Open 25 issues in our GitHub repo",
+	},
+	// GitHub-based — PRs
+	"request-ranger": {
+		name: "Request Ranger",
+		body: "Open a pull request in our GitHub repo",
+	},
+	"request-racer": {
+		name: "Request Racer",
+		body: "Open 3 pull requests in our GitHub repo",
+	},
+	"request-robot": {
+		name: "Request Robot",
+		body: "Open 5 pull requests in our GitHub repo",
+	},
+	"request-rampage": {
+		name: "Request Rampage",
+		body: "Open 10 pull requests in our GitHub repo",
+	},
+	"rabid-requester": {
+		name: "Rabid Requester",
+		body: "Open 30 pull requests in our GitHub repo",
+	},
+};
+
+function getAchievementDisplay(
+	id: string,
+	totalWordCount: number,
+): AchievementDisplay | null {
+	if (id === "words-words-words") {
+		return {
+			name: "Words words words",
+			body: `Wrote ${totalWordCount.toLocaleString("en")} words!`,
+		};
+	}
+
+	// Year-based contributor badges: "{year}-contributor"
+	const yearMatch = /^(\d{4})-contributor$/.exec(id);
+	if (yearMatch) {
+		const year = yearMatch[1];
+		return {
+			name: `${year} Contributor`,
+			body: `Make a commit to the site in ${year}!`,
+		};
+	}
+
+	return FIXED_ACHIEVEMENT_DISPLAY[id] ?? null;
+}
+
+// ── Route ─────────────────────────────────────────────────────────────────────
+
+const AuthorParamsSchema = Type.Object({
+	slug: Type.String(),
+});
+
+const AchievementSchema = Type.Object({
+	id: Type.String(),
+	name: Type.String(),
+	body: Type.String(),
+});
+
+const AuthorResponseSchema = Type.Object({
+	id: Type.String(),
+	name: Type.String(),
+	description: Type.String(),
+	profileImageUrl: Type.Optional(Type.String()),
+	socials: Type.Record(Type.String(), Type.String()),
+	roles: Type.Array(Type.String()),
+	achievements: Type.Array(AchievementSchema),
+});
+
+type AuthorResponse = Static<typeof AuthorResponseSchema>;
+
+const authorsRoutes: FastifyPluginAsync = async (fastify) => {
+	fastify.get<{
+		Params: Static<typeof AuthorParamsSchema>;
+		Reply: AuthorResponse | { error: string };
+	}>(
+		"/content/authors/:slug",
+		{
+			schema: {
+				description: "Fetch an author profile with their earned achievements",
+				params: AuthorParamsSchema,
+				response: {
+					200: {
+						description: "Successful",
+						content: {
+							"application/json": { schema: AuthorResponseSchema },
+						},
+					},
+				},
+			},
+		},
+		async (request, reply) => {
+			const { slug } = request.params;
+
+			const profile = await db.query.profiles.findFirst({
+				where: { slug },
+				with: { achievements: true },
+			});
+
+			if (!profile) {
+				reply.code(404);
+				reply.send({ error: "Author not found" });
+				return;
+			}
+
+			const meta = profile.meta as {
+				socials?: Record<string, string>;
+				roles?: string[];
+			};
+
+			// Only fetch total word count if the author has the words-words-words
+			// achievement — avoids an unnecessary join for everyone else.
+			const hasWordsAchievement = profile.achievements.some(
+				(a) => a.achievementId === "words-words-words",
+			);
+
+			let totalWordCount = 0;
+			if (hasWordsAchievement) {
+				const wordCountResult = await db
+					.select({ total: sum(postData.wordCount) })
+					.from(postAuthors)
+					.innerJoin(
+						postData,
+						and(
+							eq(postData.slug, postAuthors.postSlug),
+							eq(postData.locale, "en"),
+						),
+					)
+					.where(eq(postAuthors.authorSlug, slug));
+				totalWordCount = Number(wordCountResult[0]?.total ?? 0);
+			}
+
+			const achievements = profile.achievements
+				.map((a) => {
+					const display = getAchievementDisplay(
+						a.achievementId,
+						totalWordCount,
+					);
+					if (!display) return null;
+					return { id: a.achievementId, ...display };
+				})
+				.filter((a): a is NonNullable<typeof a> => a !== null);
+
+			const response: AuthorResponse = {
+				id: profile.slug,
+				name: profile.name,
+				description: profile.description,
+				profileImageUrl: profile.profileImage
+					? createImageUrl(profile.profileImage)
+					: undefined,
+				socials: meta.socials ?? {},
+				roles: meta.roles ?? [],
+				achievements,
+			};
+
+			reply.code(200);
+			reply.send(response);
+		},
+	);
+};
+
+export default authorsRoutes;

--- a/apps/api/src/routes/content/authors.ts
+++ b/apps/api/src/routes/content/authors.ts
@@ -154,6 +154,10 @@ const AuthorResponseSchema = Type.Object({
 
 type AuthorResponse = Static<typeof AuthorResponseSchema>;
 
+const AuthorErrorResponseSchema = Type.Object({
+	error: Type.String(),
+});
+
 const authorsRoutes: FastifyPluginAsync = async (fastify) => {
 	fastify.get<{
 		Params: Static<typeof AuthorParamsSchema>;
@@ -169,6 +173,12 @@ const authorsRoutes: FastifyPluginAsync = async (fastify) => {
 						description: "Successful",
 						content: {
 							"application/json": { schema: AuthorResponseSchema },
+						},
+					},
+					404: {
+						description: "Author not found",
+						content: {
+							"application/json": { schema: AuthorErrorResponseSchema },
 						},
 					},
 				},

--- a/apps/api/src/routes/content/authors.ts
+++ b/apps/api/src/routes/content/authors.ts
@@ -1,134 +1,7 @@
 import type { FastifyPluginAsync } from "fastify";
-import { db, postAuthors, postData } from "@playfulprogramming/db";
+import { db } from "@playfulprogramming/db";
 import { Type, type Static } from "typebox";
-import { and, eq, sum } from "drizzle-orm";
 import { createImageUrl } from "../../utils.ts";
-
-// ── Achievement display map ────────────────────────────────────────────────────
-
-type AchievementDisplay = { name: string; body: string };
-
-const FIXED_ACHIEVEMENT_DISPLAY: Record<string, AchievementDisplay> = {
-	// Manual
-	"site-redesign": { name: "Redesign Ruler", body: "Led a site-wide redesign" },
-	"site-logo": { name: "Logo Legacy", body: "Made our Unicorn logo!" },
-	"code-challenge": {
-		name: "Code Challenger",
-		body: "Make a code challenge in our Discord",
-	},
-	partner: {
-		name: "Proud partner",
-		body: "Become a Playful Programming Partner",
-	},
-	"messages-200": {
-		name: "Moderate Messager",
-		body: "Send 200 messages in our Discord",
-	},
-	"messages-500": {
-		name: "Monstrous Messager",
-		body: "Send 500 messages in our Discord",
-	},
-	"messages-1000": {
-		name: "Message Madness",
-		body: "Send 1000 messages in our Discord",
-	},
-	// Role-based
-	"hello-world": { name: "Hello, World!", body: "Earn your first role badge" },
-	"badge-collector": {
-		name: "Badge Collector",
-		body: "Have at least 3 role badges",
-	},
-	"localizer-9000": {
-		name: "Localizer 9000",
-		body: "Translate part of Playful Programming into another language!",
-	},
-	"community-crowned": {
-		name: "Community crowned",
-		body: "Become a community leader",
-	},
-	// Content-based
-	"words-words-words": {
-		name: "Words words words",
-		body: "", // body is computed dynamically from total word count
-	},
-	"it-keeps-going": {
-		name: "It Keeps Going",
-		body: "Write a really long article",
-	},
-	"politely-posting": { name: "Politely Posting", body: "Write 3 articles!" },
-	"profusely-posting": {
-		name: "Profusely Posting",
-		body: "Write 5 articles!",
-	},
-	"post-palooza": { name: "Post-palooza", body: "Write 10 articles!" },
-	"cream-of-the-crop": {
-		name: "Cream of the crop",
-		body: "Write 30 articles!",
-	},
-	"team-player": {
-		name: "Team Player",
-		body: "Collaborate on an article with another author",
-	},
-	"collect-em-all": {
-		name: "Collect 'em all",
-		body: "Author a collection of posts!",
-	},
-	// GitHub-based — issues
-	bug: { name: "Bug!", body: "Open an issue in our GitHub repo" },
-	"creepy-crawlies": {
-		name: "Creepy crawlies!",
-		body: "Open 10 issues in our GitHub repo",
-	},
-	"insect-infestation": {
-		name: "Insect infestation!",
-		body: "Open 25 issues in our GitHub repo",
-	},
-	// GitHub-based — PRs
-	"request-ranger": {
-		name: "Request Ranger",
-		body: "Open a pull request in our GitHub repo",
-	},
-	"request-racer": {
-		name: "Request Racer",
-		body: "Open 3 pull requests in our GitHub repo",
-	},
-	"request-robot": {
-		name: "Request Robot",
-		body: "Open 5 pull requests in our GitHub repo",
-	},
-	"request-rampage": {
-		name: "Request Rampage",
-		body: "Open 10 pull requests in our GitHub repo",
-	},
-	"rabid-requester": {
-		name: "Rabid Requester",
-		body: "Open 30 pull requests in our GitHub repo",
-	},
-};
-
-function getAchievementDisplay(
-	id: string,
-	totalWordCount: number,
-): AchievementDisplay | null {
-	if (id === "words-words-words") {
-		return {
-			name: "Words words words",
-			body: `Wrote ${totalWordCount.toLocaleString("en")} words!`,
-		};
-	}
-
-	// Year-based contributor badges: "{year}-contributor"
-	const yearMatch = /^(\d{4})-contributor$/.exec(id);
-	if (yearMatch) {
-		const year = yearMatch[1];
-		return {
-			name: `${year} Contributor`,
-			body: `Make a commit to the site in ${year}!`,
-		};
-	}
-
-	return FIXED_ACHIEVEMENT_DISPLAY[id] ?? null;
-}
 
 // ── Route ─────────────────────────────────────────────────────────────────────
 
@@ -138,8 +11,7 @@ const AuthorParamsSchema = Type.Object({
 
 const AchievementSchema = Type.Object({
 	id: Type.String(),
-	name: Type.String(),
-	body: Type.String(),
+	grantedAt: Type.String({ format: "date-time" }),
 });
 
 const AuthorResponseSchema = Type.Object({
@@ -203,38 +75,10 @@ const authorsRoutes: FastifyPluginAsync = async (fastify) => {
 				roles?: string[];
 			};
 
-			// Only fetch total word count if the author has the words-words-words
-			// achievement — avoids an unnecessary join for everyone else.
-			const hasWordsAchievement = profile.achievements.some(
-				(a) => a.achievementId === "words-words-words",
-			);
-
-			let totalWordCount = 0;
-			if (hasWordsAchievement) {
-				const wordCountResult = await db
-					.select({ total: sum(postData.wordCount) })
-					.from(postAuthors)
-					.innerJoin(
-						postData,
-						and(
-							eq(postData.slug, postAuthors.postSlug),
-							eq(postData.locale, "en"),
-						),
-					)
-					.where(eq(postAuthors.authorSlug, slug));
-				totalWordCount = Number(wordCountResult[0]?.total ?? 0);
-			}
-
-			const achievements = profile.achievements
-				.map((a) => {
-					const display = getAchievementDisplay(
-						a.achievementId,
-						totalWordCount,
-					);
-					if (!display) return null;
-					return { id: a.achievementId, ...display };
-				})
-				.filter((a): a is NonNullable<typeof a> => a !== null);
+			const achievements = profile.achievements.map((a) => ({
+				id: a.achievementId,
+				grantedAt: a.grantedAt.toISOString(),
+			}));
 
 			const response: AuthorResponse = {
 				id: profile.slug,

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -8,4 +8,8 @@ createWorker(Tasks.SYNC_ALL, "./tasks/sync-all/processor.ts");
 createWorker(Tasks.SYNC_AUTHOR, "./tasks/sync-author/processor.ts");
 createWorker(Tasks.SYNC_COLLECTION, "./tasks/sync-collection/processor.ts");
 createWorker(Tasks.SYNC_POST, "./tasks/sync-post/processor.ts");
+createWorker(
+	Tasks.GRANT_AUTHOR_ACHIEVEMENTS,
+	"./tasks/grant-author-achievements/processor.ts",
+);
 createHealthcheck();

--- a/apps/worker/src/tasks/grant-author-achievements/achievement-ids.ts
+++ b/apps/worker/src/tasks/grant-author-achievements/achievement-ids.ts
@@ -1,3 +1,5 @@
+import { contributorYears } from "@playfulprogramming/github-api";
+
 export const MANUAL_ACHIEVEMENT_IDS = [
 	"site-redesign",
 	"site-logo",
@@ -25,16 +27,6 @@ interface AchievementRuleInput {
 interface AchievementRule {
 	id: string;
 	check: (input: AchievementRuleInput) => boolean;
-}
-
-const FIRST_CONTRIBUTOR_YEAR = 2019;
-
-function contributorYears(): number[] {
-	const years: number[] = [];
-	for (let y = FIRST_CONTRIBUTOR_YEAR; y <= new Date().getFullYear(); y++) {
-		years.push(y);
-	}
-	return years;
 }
 
 export const ACHIEVEMENT_RULES: AchievementRule[] = [

--- a/apps/worker/src/tasks/grant-author-achievements/achievement-ids.ts
+++ b/apps/worker/src/tasks/grant-author-achievements/achievement-ids.ts
@@ -1,0 +1,147 @@
+export const MANUAL_ACHIEVEMENT_IDS = [
+	"site-redesign",
+	"site-logo",
+	"code-challenge",
+	"partner",
+	"messages-200",
+	"messages-500",
+	"messages-1000",
+] as const;
+
+interface AchievementRuleInput {
+	roles: string[];
+	postCount: number;
+	maxPostWordCount: number;
+	totalWordCount: number;
+	hasCoAuthoredPost: boolean;
+	collectionCount: number;
+	github?: {
+		issueCount: number;
+		pullRequestCount: number;
+		commitsInYear: number[];
+	};
+}
+
+interface AchievementRule {
+	id: string;
+	check: (input: AchievementRuleInput) => boolean;
+}
+
+const FIRST_CONTRIBUTOR_YEAR = 2019;
+
+function contributorYears(): number[] {
+	const years: number[] = [];
+	for (let y = FIRST_CONTRIBUTOR_YEAR; y <= new Date().getFullYear(); y++) {
+		years.push(y);
+	}
+	return years;
+}
+
+export const ACHIEVEMENT_RULES: AchievementRule[] = [
+	// Role-based — role count tier (exclusive: only highest)
+	{
+		id: "badge-collector",
+		check: ({ roles }) => roles.length >= 3,
+	},
+	{
+		id: "hello-world",
+		check: ({ roles }) => roles.length >= 1 && roles.length < 3,
+	},
+	// Role-based — specific roles (not exclusive with role count tier)
+	{
+		id: "localizer-9000",
+		check: ({ roles }) => roles.includes("translator"),
+	},
+	{
+		id: "community-crowned",
+		check: ({ roles }) => roles.includes("community"),
+	},
+	// Content-based — post count tier (exclusive: only highest)
+	{
+		id: "cream-of-the-crop",
+		check: ({ postCount }) => postCount >= 30,
+	},
+	{
+		id: "post-palooza",
+		check: ({ postCount }) => postCount >= 10 && postCount < 30,
+	},
+	{
+		id: "profusely-posting",
+		check: ({ postCount }) => postCount >= 5 && postCount < 10,
+	},
+	{
+		id: "politely-posting",
+		check: ({ postCount }) => postCount >= 3 && postCount < 5,
+	},
+	// Content-based — not exclusive
+	{
+		id: "words-words-words",
+		check: ({ totalWordCount }) => totalWordCount > 0,
+	},
+	{
+		id: "it-keeps-going",
+		check: ({ maxPostWordCount }) => maxPostWordCount >= 6000,
+	},
+	{
+		id: "team-player",
+		check: ({ hasCoAuthoredPost }) => hasCoAuthoredPost,
+	},
+	{
+		id: "collect-em-all",
+		check: ({ collectionCount }) => collectionCount > 0,
+	},
+	// GitHub-based — issue count tier (exclusive: only highest)
+	{
+		id: "insect-infestation",
+		check: ({ github }) => (github?.issueCount ?? 0) >= 25,
+	},
+	{
+		id: "creepy-crawlies",
+		check: ({ github }) =>
+			(github?.issueCount ?? 0) >= 10 && (github?.issueCount ?? 0) < 25,
+	},
+	{
+		id: "bug",
+		check: ({ github }) =>
+			(github?.issueCount ?? 0) >= 1 && (github?.issueCount ?? 0) < 10,
+	},
+	// GitHub-based — PR count tier (exclusive: only highest)
+	{
+		id: "rabid-requester",
+		check: ({ github }) => (github?.pullRequestCount ?? 0) >= 30,
+	},
+	{
+		id: "request-rampage",
+		check: ({ github }) =>
+			(github?.pullRequestCount ?? 0) >= 10 &&
+			(github?.pullRequestCount ?? 0) < 30,
+	},
+	{
+		id: "request-robot",
+		check: ({ github }) =>
+			(github?.pullRequestCount ?? 0) >= 5 &&
+			(github?.pullRequestCount ?? 0) < 10,
+	},
+	{
+		id: "request-racer",
+		check: ({ github }) =>
+			(github?.pullRequestCount ?? 0) >= 3 &&
+			(github?.pullRequestCount ?? 0) < 5,
+	},
+	{
+		id: "request-ranger",
+		check: ({ github }) =>
+			(github?.pullRequestCount ?? 0) >= 1 &&
+			(github?.pullRequestCount ?? 0) < 3,
+	},
+	// GitHub-based — yearly commits (one per year, not exclusive)
+	...contributorYears().map((year) => ({
+		id: `${year}-contributor`,
+		check: ({ github }: AchievementRuleInput) =>
+			github?.commitsInYear.includes(year) ?? false,
+	})),
+];
+
+export const ALL_POSSIBLE_AUTO_IDS: string[] = ACHIEVEMENT_RULES.map(
+	(r) => r.id,
+);

--- a/apps/worker/src/tasks/grant-author-achievements/processor.ts
+++ b/apps/worker/src/tasks/grant-author-achievements/processor.ts
@@ -87,12 +87,7 @@ export default createProcessor(Tasks.GRANT_AUTHOR_ACHIEVEMENTS, async (job) => {
 	// ── GitHub stats ──────────────────────────────────────────────────────────
 
 	const githubStats = githubLogin
-		? await github.getAuthorGitHubStats(githubLogin).catch((e) => {
-				console.warn(
-					`grant-author-achievements: GitHub stats fetch failed for ${profileSlug}: ${e}`,
-				);
-				return undefined;
-			})
+		? await github.getAuthorGitHubStats(githubLogin)
 		: undefined;
 
 	// ── Evaluate rules ────────────────────────────────────────────────────────

--- a/apps/worker/src/tasks/grant-author-achievements/processor.ts
+++ b/apps/worker/src/tasks/grant-author-achievements/processor.ts
@@ -5,24 +5,24 @@ import {
 	postAuthors,
 	postData,
 	collectionAuthors,
+	collectionData,
 } from "@playfulprogramming/db";
 import * as github from "@playfulprogramming/github-api";
 import { createProcessor } from "../../createProcessor.ts";
-import { and, eq, inArray, max, count, ne } from "drizzle-orm";
+import { and, eq, inArray, max, count, ne, isNotNull } from "drizzle-orm";
 import { ACHIEVEMENT_RULES, ALL_POSSIBLE_AUTO_IDS } from "./achievement-ids.ts";
 
 export default createProcessor(Tasks.GRANT_AUTHOR_ACHIEVEMENTS, async (job) => {
-	const { profileSlug, ref: _ref } = job.data;
+	const { profileSlug } = job.data;
 
 	const profile = await db.query.profiles.findFirst({
 		where: { slug: profileSlug },
 	});
 
 	if (!profile) {
-		console.log(
-			`grant-author-achievements: profile ${profileSlug} not found, skipping.`,
+		throw new Error(
+			`grant-author-achievements: profile ${profileSlug} not found.`,
 		);
-		return;
 	}
 
 	const meta = profile.meta as {
@@ -47,7 +47,12 @@ export default createProcessor(Tasks.GRANT_AUTHOR_ACHIEVEMENTS, async (job) => {
 			postData,
 			and(eq(postData.slug, postAuthors.postSlug), eq(postData.locale, "en")),
 		)
-		.where(eq(postAuthors.authorSlug, profileSlug))
+		.where(
+			and(
+				eq(postAuthors.authorSlug, profileSlug),
+				isNotNull(postData.publishedAt),
+			),
+		)
 		.groupBy(postAuthors.postSlug);
 
 	const postCount = wordCountRows.length;
@@ -81,7 +86,19 @@ export default createProcessor(Tasks.GRANT_AUTHOR_ACHIEVEMENTS, async (job) => {
 	const collectionCountResult = await db
 		.select({ value: count() })
 		.from(collectionAuthors)
-		.where(eq(collectionAuthors.authorSlug, profileSlug));
+		.innerJoin(
+			collectionData,
+			and(
+				eq(collectionData.slug, collectionAuthors.collectionSlug),
+				eq(collectionData.locale, "en"),
+			),
+		)
+		.where(
+			and(
+				eq(collectionAuthors.authorSlug, profileSlug),
+				isNotNull(collectionData.publishedAt),
+			),
+		);
 	const collectionCount = collectionCountResult[0]?.value ?? 0;
 
 	// ── GitHub stats ──────────────────────────────────────────────────────────

--- a/apps/worker/src/tasks/grant-author-achievements/processor.ts
+++ b/apps/worker/src/tasks/grant-author-achievements/processor.ts
@@ -1,0 +1,139 @@
+import { Tasks } from "@playfulprogramming/bullmq";
+import {
+	db,
+	profileAchievements,
+	postAuthors,
+	postData,
+	collectionAuthors,
+} from "@playfulprogramming/db";
+import * as github from "@playfulprogramming/github-api";
+import { createProcessor } from "../../createProcessor.ts";
+import { and, eq, inArray, max, count, ne } from "drizzle-orm";
+import { ACHIEVEMENT_RULES, ALL_POSSIBLE_AUTO_IDS } from "./achievement-ids.ts";
+
+export default createProcessor(Tasks.GRANT_AUTHOR_ACHIEVEMENTS, async (job) => {
+	const { profileSlug, ref: _ref } = job.data;
+
+	const profile = await db.query.profiles.findFirst({
+		where: { slug: profileSlug },
+	});
+
+	if (!profile) {
+		console.log(
+			`grant-author-achievements: profile ${profileSlug} not found, skipping.`,
+		);
+		return;
+	}
+
+	const meta = profile.meta as {
+		roles?: string[];
+		socials?: Record<string, string>;
+	};
+	const roles = meta.roles ?? [];
+	const githubLogin = meta.socials?.github;
+
+	// ── Content stats ─────────────────────────────────────────────────────────
+
+	// Word count per post (English locale only, matching frontend behaviour).
+	// We take the max across versions since postData has a composite PK of
+	// (slug, locale, version).
+	const wordCountRows = await db
+		.select({
+			postSlug: postAuthors.postSlug,
+			wordCount: max(postData.wordCount),
+		})
+		.from(postAuthors)
+		.innerJoin(
+			postData,
+			and(eq(postData.slug, postAuthors.postSlug), eq(postData.locale, "en")),
+		)
+		.where(eq(postAuthors.authorSlug, profileSlug))
+		.groupBy(postAuthors.postSlug);
+
+	const postCount = wordCountRows.length;
+	const maxPostWordCount = wordCountRows.reduce(
+		(acc, r) => Math.max(acc, r.wordCount ?? 0),
+		0,
+	);
+	const totalWordCount = wordCountRows.reduce(
+		(acc, r) => acc + (r.wordCount ?? 0),
+		0,
+	);
+
+	// Co-authored: any post this author shares with at least one other author.
+	// We already have the post slugs, so just look for rows with a different authorSlug.
+	let hasCoAuthoredPost = false;
+	if (wordCountRows.length > 0) {
+		const postSlugs = wordCountRows.map((r) => r.postSlug);
+		const coAuthorRows = await db
+			.select({ value: count() })
+			.from(postAuthors)
+			.where(
+				and(
+					inArray(postAuthors.postSlug, postSlugs),
+					ne(postAuthors.authorSlug, profileSlug),
+				),
+			);
+		hasCoAuthoredPost = (coAuthorRows[0]?.value ?? 0) > 0;
+	}
+
+	// Collection count
+	const collectionCountResult = await db
+		.select({ value: count() })
+		.from(collectionAuthors)
+		.where(eq(collectionAuthors.authorSlug, profileSlug));
+	const collectionCount = collectionCountResult[0]?.value ?? 0;
+
+	// ── GitHub stats ──────────────────────────────────────────────────────────
+
+	const githubStats = githubLogin
+		? await github.getAuthorGitHubStats(githubLogin).catch((e) => {
+				console.warn(
+					`grant-author-achievements: GitHub stats fetch failed for ${profileSlug}: ${e}`,
+				);
+				return undefined;
+			})
+		: undefined;
+
+	// ── Evaluate rules ────────────────────────────────────────────────────────
+
+	const earnedIds = ACHIEVEMENT_RULES.filter((rule) =>
+		rule.check({
+			roles,
+			postCount,
+			maxPostWordCount,
+			totalWordCount,
+			hasCoAuthoredPost,
+			collectionCount,
+			github: githubStats,
+		}),
+	).map((rule) => rule.id);
+
+	// ── Write results ─────────────────────────────────────────────────────────
+	// Delete all rows for this profile that are in the auto-computed set, then
+	// re-insert only the earned subset. Manual achievement rows are never touched.
+
+	await db.transaction(async (tx) => {
+		await tx
+			.delete(profileAchievements)
+			.where(
+				and(
+					eq(profileAchievements.profileSlug, profileSlug),
+					inArray(profileAchievements.achievementId, ALL_POSSIBLE_AUTO_IDS),
+				),
+			);
+
+		if (earnedIds.length > 0) {
+			await tx.insert(profileAchievements).values(
+				earnedIds.map((achievementId) => ({
+					profileSlug,
+					achievementId,
+				})),
+			);
+		}
+	});
+
+	console.log(
+		`grant-author-achievements: ${profileSlug} → ${earnedIds.length} auto achievements granted (${earnedIds.join(", ")})`,
+	);
+});

--- a/apps/worker/src/tasks/sync-author/processor.ts
+++ b/apps/worker/src/tasks/sync-author/processor.ts
@@ -1,6 +1,6 @@
 import { env } from "@playfulprogramming/common";
-import { Tasks } from "@playfulprogramming/bullmq";
-import { db, profiles } from "@playfulprogramming/db";
+import { Tasks, createJob } from "@playfulprogramming/bullmq";
+import { db, profiles, profileAchievements } from "@playfulprogramming/db";
 import * as github from "@playfulprogramming/github-api";
 import { s3 } from "@playfulprogramming/s3";
 import { createProcessor } from "../../createProcessor.ts";
@@ -9,7 +9,8 @@ import { AuthorMetaSchema } from "./types.ts";
 import { Value } from "typebox/value";
 import sharp from "sharp";
 import { Readable } from "node:stream";
-import { eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
+import { MANUAL_ACHIEVEMENT_IDS } from "../grant-author-achievements/achievement-ids.ts";
 
 const PROFILE_IMAGE_SIZE_MAX = 2048;
 
@@ -93,8 +94,42 @@ export default createProcessor(Tasks.SYNC_AUTHOR, async (job, { signal }) => {
 		},
 	};
 
-	await db
-		.insert(profiles)
-		.values(result)
-		.onConflictDoUpdate({ target: profiles.slug, set: result });
+	const earnedManualIds = authorData.achievements.filter(
+		(id): id is (typeof MANUAL_ACHIEVEMENT_IDS)[number] =>
+			(MANUAL_ACHIEVEMENT_IDS as readonly string[]).includes(id),
+	);
+
+	await db.transaction(async (tx) => {
+		await tx
+			.insert(profiles)
+			.values(result)
+			.onConflictDoUpdate({ target: profiles.slug, set: result });
+
+		await tx
+			.delete(profileAchievements)
+			.where(
+				and(
+					eq(profileAchievements.profileSlug, authorId),
+					inArray(
+						profileAchievements.achievementId,
+						MANUAL_ACHIEVEMENT_IDS as unknown as string[],
+					),
+				),
+			);
+
+		if (earnedManualIds.length > 0) {
+			await tx.insert(profileAchievements).values(
+				earnedManualIds.map((achievementId) => ({
+					profileSlug: authorId,
+					achievementId,
+				})),
+			);
+		}
+	});
+
+	await createJob(
+		Tasks.GRANT_AUTHOR_ACHIEVEMENTS,
+		`grant-author-achievements:${authorId}`,
+		{ profileSlug: authorId, ref: job.data.ref },
+	);
 });

--- a/apps/worker/src/tasks/sync-author/processor.ts
+++ b/apps/worker/src/tasks/sync-author/processor.ts
@@ -130,6 +130,6 @@ export default createProcessor(Tasks.SYNC_AUTHOR, async (job, { signal }) => {
 	await createJob(
 		Tasks.GRANT_AUTHOR_ACHIEVEMENTS,
 		`grant-author-achievements:${authorId}`,
-		{ profileSlug: authorId, ref: job.data.ref },
+		{ profileSlug: authorId },
 	);
 });

--- a/apps/worker/src/tasks/sync-author/processor.ts
+++ b/apps/worker/src/tasks/sync-author/processor.ts
@@ -94,7 +94,7 @@ export default createProcessor(Tasks.SYNC_AUTHOR, async (job, { signal }) => {
 		},
 	};
 
-	const earnedManualIds = authorData.achievements.filter(
+	const earnedManualIds = [...new Set(authorData.achievements)].filter(
 		(id): id is (typeof MANUAL_ACHIEVEMENT_IDS)[number] =>
 			(MANUAL_ACHIEVEMENT_IDS as readonly string[]).includes(id),
 	);

--- a/apps/worker/src/tasks/sync-author/types.ts
+++ b/apps/worker/src/tasks/sync-author/types.ts
@@ -7,6 +7,7 @@ export const AuthorMetaSchema = Type.Object(
 		profileImg: Type.Optional(Type.String()),
 		socials: Type.Record(Type.String(), Type.String(), { default: {} }),
 		roles: Type.Array(Type.String(), { default: [] }),
+		achievements: Type.Array(Type.String(), { default: [] }),
 	},
 	{
 		additionalProperties: false,

--- a/apps/worker/src/tasks/sync-collection/processor.ts
+++ b/apps/worker/src/tasks/sync-collection/processor.ts
@@ -1,5 +1,5 @@
 import { env } from "@playfulprogramming/common";
-import { Tasks } from "@playfulprogramming/bullmq";
+import { Tasks, createJob } from "@playfulprogramming/bullmq";
 import {
 	collectionAuthors,
 	collectionData,
@@ -96,6 +96,10 @@ export default createProcessor(
 			[] as Array<{ entry: Entry; locale: string }>,
 		);
 
+		// Accumulate all unique author slugs touched across locale iterations
+		// so we can enqueue achievements for each of them after the loop.
+		const touchedAuthorSlugs = new Set<string>();
+
 		// Check if coverImg or socialImg have changed since last edit, if so upload to S3
 		for (const { entry, locale } of collectionEntries) {
 			const contentUrl = new URL(entry.path, "http://localhost");
@@ -187,6 +191,8 @@ export default createProcessor(
 				? [...new Set([...collectionParsedData.authors, authorId])]
 				: [authorId];
 
+			authorSlugs.forEach((s) => touchedAuthorSlugs.add(s));
+
 			await db.transaction(async (tx) => {
 				await tx
 					.insert(collections)
@@ -216,6 +222,14 @@ export default createProcessor(
 					);
 				}
 			});
+		}
+
+		for (const authorSlug of touchedAuthorSlugs) {
+			await createJob(
+				Tasks.GRANT_AUTHOR_ACHIEVEMENTS,
+				`grant-author-achievements:${authorSlug}`,
+				{ profileSlug: authorSlug, ref: job.data.ref },
+			);
 		}
 	},
 );

--- a/apps/worker/src/tasks/sync-collection/processor.ts
+++ b/apps/worker/src/tasks/sync-collection/processor.ts
@@ -228,7 +228,7 @@ export default createProcessor(
 			await createJob(
 				Tasks.GRANT_AUTHOR_ACHIEVEMENTS,
 				`grant-author-achievements:${authorSlug}`,
-				{ profileSlug: authorSlug, ref: job.data.ref },
+				{ profileSlug: authorSlug },
 			);
 		}
 	},

--- a/apps/worker/src/tasks/sync-post/processor.test.ts
+++ b/apps/worker/src/tasks/sync-post/processor.test.ts
@@ -1,5 +1,5 @@
 import processor from "./processor.ts";
-import type { TaskInputs } from "@playfulprogramming/bullmq";
+import { createJob, type TaskInputs, Tasks } from "@playfulprogramming/bullmq";
 import type { Job } from "bullmq";
 import { posts, postData, postAuthors, db } from "@playfulprogramming/db";
 import { s3 } from "@playfulprogramming/s3";
@@ -135,6 +135,17 @@ test("Deletes a post record if it no longer exists", async () => {
 		where: deleteWhere,
 	} as never);
 
+	vi.mocked(db.select).mockReturnValue({
+		from: vi.fn().mockReturnValue({
+			where: vi
+				.fn()
+				.mockResolvedValue([
+					{ authorSlug: "example-author" },
+					{ authorSlug: "co-author" },
+				]),
+		}),
+	} as never);
+
 	// Mock GitHub: return 404
 	vi.mocked(github.getContents).mockImplementation(((params: {
 		path: string;
@@ -160,6 +171,18 @@ test("Deletes a post record if it no longer exists", async () => {
 	// Assert: Post was deleted from posts table (cascade handles related tables)
 	expect(db.delete).toBeCalledWith(posts);
 	expect(deleteWhere).toBeCalledWith(eq(posts.slug, "example-post"));
+
+	// Assert: Achievements re-evaluated for the authors who were on the post
+	expect(createJob).toBeCalledWith(
+		Tasks.GRANT_AUTHOR_ACHIEVEMENTS,
+		"grant-author-achievements:example-author",
+		{ profileSlug: "example-author", ref: "main" },
+	);
+	expect(createJob).toBeCalledWith(
+		Tasks.GRANT_AUTHOR_ACHIEVEMENTS,
+		"grant-author-achievements:co-author",
+		{ profileSlug: "co-author", ref: "main" },
+	);
 });
 
 test("Links post to collection when collection is provided", async () => {

--- a/apps/worker/src/tasks/sync-post/processor.test.ts
+++ b/apps/worker/src/tasks/sync-post/processor.test.ts
@@ -33,6 +33,12 @@ test("Syncs a standalone post successfully", async () => {
 		where: deleteWhere,
 	} as never);
 
+	vi.mocked(db.select).mockReturnValue({
+		from: vi.fn().mockReturnValue({
+			where: vi.fn().mockResolvedValue([]),
+		}),
+	} as never);
+
 	// Mock GitHub: return folder listing with index.md
 	vi.mocked(github.getContents).mockImplementation(((params: {
 		path: string;
@@ -183,6 +189,12 @@ test("Links post to collection when collection is provided", async () => {
 		where: deleteWhere,
 	} as never);
 
+	vi.mocked(db.select).mockReturnValue({
+		from: vi.fn().mockReturnValue({
+			where: vi.fn().mockResolvedValue([]),
+		}),
+	} as never);
+
 	// Note: collection path format
 	vi.mocked(github.getContents).mockImplementation(((params: {
 		path: string;
@@ -268,6 +280,12 @@ test("Syncs post with multiple locales", async () => {
 	const deleteWhere = vi.fn();
 	vi.mocked(db.delete).mockReturnValue({
 		where: deleteWhere,
+	} as never);
+
+	vi.mocked(db.select).mockReturnValue({
+		from: vi.fn().mockReturnValue({
+			where: vi.fn().mockResolvedValue([]),
+		}),
 	} as never);
 
 	// Return folder listing with both index.md and index.es.md
@@ -388,6 +406,12 @@ test("Handles post with multiple authors", async () => {
 	const deleteWhere = vi.fn();
 	vi.mocked(db.delete).mockReturnValue({
 		where: deleteWhere,
+	} as never);
+
+	vi.mocked(db.select).mockReturnValue({
+		from: vi.fn().mockReturnValue({
+			where: vi.fn().mockResolvedValue([]),
+		}),
 	} as never);
 
 	vi.mocked(github.getContents).mockImplementation(((params: {

--- a/apps/worker/src/tasks/sync-post/processor.test.ts
+++ b/apps/worker/src/tasks/sync-post/processor.test.ts
@@ -176,12 +176,12 @@ test("Deletes a post record if it no longer exists", async () => {
 	expect(createJob).toBeCalledWith(
 		Tasks.GRANT_AUTHOR_ACHIEVEMENTS,
 		"grant-author-achievements:example-author",
-		{ profileSlug: "example-author", ref: "main" },
+		{ profileSlug: "example-author" },
 	);
 	expect(createJob).toBeCalledWith(
 		Tasks.GRANT_AUTHOR_ACHIEVEMENTS,
 		"grant-author-achievements:co-author",
-		{ profileSlug: "co-author", ref: "main" },
+		{ profileSlug: "co-author" },
 	);
 });
 

--- a/apps/worker/src/tasks/sync-post/processor.ts
+++ b/apps/worker/src/tasks/sync-post/processor.ts
@@ -1,5 +1,5 @@
 import { env } from "@playfulprogramming/common";
-import { Tasks } from "@playfulprogramming/bullmq";
+import { Tasks, createJob } from "@playfulprogramming/bullmq";
 import { db, posts, postData, postAuthors } from "@playfulprogramming/db";
 import * as github from "@playfulprogramming/github-api";
 import { s3 } from "@playfulprogramming/s3";
@@ -182,4 +182,15 @@ export default createProcessor(Tasks.SYNC_POST, async (job, { signal }) => {
 			})),
 		);
 	});
+
+	// Re-evaluate achievements for every author touched by this post.
+	// createJob deduplicates by key, so concurrent post syncs for the same
+	// author collapse into a single achievements job.
+	for (const authorSlug of authorSlugs) {
+		await createJob(
+			Tasks.GRANT_AUTHOR_ACHIEVEMENTS,
+			`grant-author-achievements:${authorSlug}`,
+			{ profileSlug: authorSlug, ref },
+		);
+	}
 });

--- a/apps/worker/src/tasks/sync-post/processor.ts
+++ b/apps/worker/src/tasks/sync-post/processor.ts
@@ -51,7 +51,7 @@ export default createProcessor(Tasks.SYNC_POST, async (job, { signal }) => {
 				await createJob(
 					Tasks.GRANT_AUTHOR_ACHIEVEMENTS,
 					`grant-author-achievements:${authorSlug}`,
-					{ profileSlug: authorSlug, ref },
+					{ profileSlug: authorSlug },
 				);
 			}
 
@@ -214,7 +214,7 @@ export default createProcessor(Tasks.SYNC_POST, async (job, { signal }) => {
 		await createJob(
 			Tasks.GRANT_AUTHOR_ACHIEVEMENTS,
 			`grant-author-achievements:${authorSlug}`,
-			{ profileSlug: authorSlug, ref },
+			{ profileSlug: authorSlug },
 		);
 	}
 });

--- a/apps/worker/src/tasks/sync-post/processor.ts
+++ b/apps/worker/src/tasks/sync-post/processor.ts
@@ -40,7 +40,20 @@ export default createProcessor(Tasks.SYNC_POST, async (job, { signal }) => {
 				`Post ${post} (${basePath}) returned 404 - removing from database.`,
 			);
 
+			const removedAuthorRows = await db
+				.select({ authorSlug: postAuthors.authorSlug })
+				.from(postAuthors)
+				.where(eq(postAuthors.postSlug, post));
+
 			await db.delete(posts).where(eq(posts.slug, post));
+
+			for (const { authorSlug } of removedAuthorRows) {
+				await createJob(
+					Tasks.GRANT_AUTHOR_ACHIEVEMENTS,
+					`grant-author-achievements:${authorSlug}`,
+					{ profileSlug: authorSlug, ref },
+				);
+			}
 
 			return;
 		}

--- a/apps/worker/src/tasks/sync-post/processor.ts
+++ b/apps/worker/src/tasks/sync-post/processor.ts
@@ -131,6 +131,12 @@ export default createProcessor(Tasks.SYNC_POST, async (job, { signal }) => {
 	// =========================================================================
 	// Phase 3: Perform all database operations in a single transaction
 	// =========================================================================
+	const previousAuthorRows = await db
+		.select({ authorSlug: postAuthors.authorSlug })
+		.from(postAuthors)
+		.where(eq(postAuthors.postSlug, post));
+	const previousAuthorSlugs = previousAuthorRows.map((r) => r.authorSlug);
+
 	await db.transaction(async (tx) => {
 		await tx
 			.insert(posts)
@@ -183,10 +189,15 @@ export default createProcessor(Tasks.SYNC_POST, async (job, { signal }) => {
 		);
 	});
 
-	// Re-evaluate achievements for every author touched by this post.
+	// Re-evaluate achievements for every author touched by this post, including
+	// authors removed from the frontmatter so their stats are recomputed too.
 	// createJob deduplicates by key, so concurrent post syncs for the same
 	// author collapse into a single achievements job.
-	for (const authorSlug of authorSlugs) {
+	const affectedAuthorSlugs = [
+		...new Set([...authorSlugs, ...previousAuthorSlugs]),
+	];
+
+	for (const authorSlug of affectedAuthorSlugs) {
 		await createJob(
 			Tasks.GRANT_AUTHOR_ACHIEVEMENTS,
 			`grant-author-achievements:${authorSlug}`,

--- a/apps/worker/test-utils/setup.ts
+++ b/apps/worker/test-utils/setup.ts
@@ -59,6 +59,10 @@ vi.mock("@playfulprogramming/db", () => {
 		profiles: {
 			slug: {},
 		},
+		profileAchievements: {
+			profileSlug: {},
+			achievementId: {},
+		},
 		posts: {
 			slug: {},
 		},

--- a/apps/worker/test-utils/setup.ts
+++ b/apps/worker/test-utils/setup.ts
@@ -98,8 +98,10 @@ vi.mock("@playfulprogramming/db", () => {
 	};
 });
 
-vi.mock("@playfulprogramming/github-api", () => {
+vi.mock("@playfulprogramming/github-api", async (importOriginal) => {
+	const actual = await importOriginal();
 	return {
+		...(actual as object),
 		getContents: vi.fn(),
 		getContentsRaw: vi.fn(),
 		getContentsRawStream: vi.fn(),

--- a/apps/worker/test-utils/setup.ts
+++ b/apps/worker/test-utils/setup.ts
@@ -106,5 +106,6 @@ vi.mock("@playfulprogramming/github-api", async (importOriginal) => {
 		getContentsRaw: vi.fn(),
 		getContentsRawStream: vi.fn(),
 		getGistById: vi.fn(),
+		getAuthorGitHubStats: vi.fn().mockResolvedValue(undefined),
 	};
 });

--- a/packages/bullmq/src/tasks/grant-author-achievements.ts
+++ b/packages/bullmq/src/tasks/grant-author-achievements.ts
@@ -1,0 +1,6 @@
+export interface GrantAuthorAchievementsInput {
+	profileSlug: string;
+	ref: string;
+}
+
+export type GrantAuthorAchievementsOutput = void;

--- a/packages/bullmq/src/tasks/grant-author-achievements.ts
+++ b/packages/bullmq/src/tasks/grant-author-achievements.ts
@@ -1,6 +1,5 @@
 export interface GrantAuthorAchievementsInput {
 	profileSlug: string;
-	ref: string;
 }
 
 export type GrantAuthorAchievementsOutput = void;

--- a/packages/bullmq/src/tasks/index.ts
+++ b/packages/bullmq/src/tasks/index.ts
@@ -1,3 +1,4 @@
+export * from "./grant-author-achievements.ts";
 export * from "./post-image.ts";
 export * from "./sync-all.ts";
 export * from "./types.ts";

--- a/packages/bullmq/src/tasks/types.ts
+++ b/packages/bullmq/src/tasks/types.ts
@@ -7,6 +7,10 @@ import type {
 } from "./sync-collection.ts";
 import type { SyncPostInput, SyncPostOutput } from "./sync-post.ts";
 import type { SyncAllInput } from "./sync-all.ts";
+import type {
+	GrantAuthorAchievementsInput,
+	GrantAuthorAchievementsOutput,
+} from "./grant-author-achievements.ts";
 
 export const Tasks = {
 	SYNC_ALL: "sync-all",
@@ -15,6 +19,7 @@ export const Tasks = {
 	SYNC_POST: "sync-post",
 	URL_METADATA: "url-metadata",
 	POST_IMAGES: "post-images",
+	GRANT_AUTHOR_ACHIEVEMENTS: "grant-author-achievements",
 } as const;
 
 export type TasksKeys = keyof typeof Tasks;
@@ -27,6 +32,7 @@ export interface TaskInputs {
 	[Tasks.SYNC_POST]: SyncPostInput;
 	[Tasks.URL_METADATA]: UrlMetadataInput;
 	[Tasks.POST_IMAGES]: PostImageInput;
+	[Tasks.GRANT_AUTHOR_ACHIEVEMENTS]: GrantAuthorAchievementsInput;
 }
 
 export type TaskInputsValues = TaskInputs[TasksValues];
@@ -38,6 +44,7 @@ export interface TaskOutputs {
 	[Tasks.SYNC_POST]: SyncPostOutput;
 	[Tasks.URL_METADATA]: UrlMetadataOutput;
 	[Tasks.POST_IMAGES]: PostImageOutput;
+	[Tasks.GRANT_AUTHOR_ACHIEVEMENTS]: GrantAuthorAchievementsOutput;
 }
 
 export type TaskOutputsValues = TaskOutputs[TasksValues];

--- a/packages/db/drizzle/20260620230617_thankful_angel/migration.sql
+++ b/packages/db/drizzle/20260620230617_thankful_angel/migration.sql
@@ -1,0 +1,8 @@
+CREATE TABLE "profile_achievements" (
+	"profile_slug" text,
+	"achievement_id" text,
+	"granted_at" timestamp with time zone NOT NULL,
+	CONSTRAINT "profile_achievements_pkey" PRIMARY KEY("profile_slug","achievement_id")
+);
+--> statement-breakpoint
+ALTER TABLE "profile_achievements" ADD CONSTRAINT "profile_achievements_profile_slug_profiles_slug_fkey" FOREIGN KEY ("profile_slug") REFERENCES "profiles"("slug") ON DELETE CASCADE;

--- a/packages/db/drizzle/20260620230617_thankful_angel/snapshot.json
+++ b/packages/db/drizzle/20260620230617_thankful_angel/snapshot.json
@@ -1,0 +1,1492 @@
+{
+  "version": "8",
+  "dialect": "postgres",
+  "id": "a9cd32a6-e23f-4121-bc8f-6d4282e95a3c",
+  "prevIds": [
+    "60f31ba8-78b9-4d1c-a249-b89ecc397df9"
+  ],
+  "ddl": [
+    {
+      "isRlsEnabled": false,
+      "name": "profile_achievements",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "profiles",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "collection_authors",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "collection_data",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "collections",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "post_authors",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "post_data",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "posts",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "post_images",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "url_metadata",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "url_metadata_gist",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "url_metadata_gist_file",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "url_metadata_post",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "profile_slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_achievements"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "achievement_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_achievements"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "granted_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_achievements"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "''",
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "profile_image",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profiles"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "published_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profiles"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "meta",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "collection_slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_authors"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "author_slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_authors"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "locale",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "''",
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "published_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "meta",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "cover_image",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "social_image",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collections"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "post_slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_authors"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "author_slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_authors"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "locale",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "''",
+      "generated": null,
+      "identity": null,
+      "name": "version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "''",
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "word_count",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "social_image",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "banner_image",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "original_link",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "noindex",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "edited_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "published_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "meta",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "collection_slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "collection_order",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_images"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "banner_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_images"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "link_preview_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_images"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "index_md5",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_images"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "fetched_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_images"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "error",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_images"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "url",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "icon_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "icon_width",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "icon_height",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "banner_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "banner_width",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "banner_height",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "gist_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "post_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "embed_src",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "embed_width",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "embed_height",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "embed_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "fetched_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "error",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "gist_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_gist"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "username",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_gist"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_gist"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "gist_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_gist_file"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "filename",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_gist_file"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "content_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_gist_file"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "language",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_gist_file"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "post_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "author_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "author_handle",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "content",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "url",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "avatar_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "avatar_width",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "avatar_height",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image_width",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image_height",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image_alt_text",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "num_likes",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "num_reposts",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "num_replies",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "profile_slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "profiles",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "profile_achievements_profile_slug_profiles_slug_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "profile_achievements"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "collection_slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "collections",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "collection_authors_collection_slug_collections_slug_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "collection_authors"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "author_slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "profiles",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "collection_authors_author_slug_profiles_slug_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "collection_authors"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "collections",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "collection_data_slug_collections_slug_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "post_slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "posts",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "post_authors_post_slug_posts_slug_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "post_authors"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "author_slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "profiles",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "post_authors_author_slug_profiles_slug_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "post_authors"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "posts",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "post_data_slug_posts_slug_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "collection_slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "collections",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "name": "posts_collection_slug_collections_slug_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "gist_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "url_metadata_gist",
+      "columnsTo": [
+        "gist_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "name": "url_metadata_gist_id_url_metadata_gist_gist_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "post_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "url_metadata_post",
+      "columnsTo": [
+        "post_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "name": "url_metadata_post_id_url_metadata_post_post_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "gist_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "url_metadata_gist",
+      "columnsTo": [
+        "gist_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "url_metadata_gist_file_gist_id_url_metadata_gist_gist_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "url_metadata_gist_file"
+    },
+    {
+      "columns": [
+        "profile_slug",
+        "achievement_id"
+      ],
+      "nameExplicit": false,
+      "name": "profile_achievements_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "profile_achievements"
+    },
+    {
+      "columns": [
+        "collection_slug",
+        "author_slug"
+      ],
+      "nameExplicit": false,
+      "name": "collection_authors_collection_slug_author_slug_pk",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "collection_authors"
+    },
+    {
+      "columns": [
+        "slug",
+        "locale"
+      ],
+      "nameExplicit": false,
+      "name": "collection_data_slug_locale_pk",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "columns": [
+        "post_slug",
+        "author_slug"
+      ],
+      "nameExplicit": false,
+      "name": "post_authors_post_slug_author_slug_pk",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "post_authors"
+    },
+    {
+      "columns": [
+        "slug",
+        "locale",
+        "version"
+      ],
+      "nameExplicit": false,
+      "name": "post_data_slug_locale_version_pk",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "columns": [
+        "gist_id",
+        "filename"
+      ],
+      "nameExplicit": false,
+      "name": "url_metadata_gist_file_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "url_metadata_gist_file"
+    },
+    {
+      "columns": [
+        "slug"
+      ],
+      "nameExplicit": false,
+      "name": "profiles_pkey",
+      "schema": "public",
+      "table": "profiles",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "slug"
+      ],
+      "nameExplicit": false,
+      "name": "collections_pkey",
+      "schema": "public",
+      "table": "collections",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "slug"
+      ],
+      "nameExplicit": false,
+      "name": "posts_pkey",
+      "schema": "public",
+      "table": "posts",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "slug"
+      ],
+      "nameExplicit": false,
+      "name": "post_images_pkey",
+      "schema": "public",
+      "table": "post_images",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "url"
+      ],
+      "nameExplicit": false,
+      "name": "url_metadata_pkey",
+      "schema": "public",
+      "table": "url_metadata",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "gist_id"
+      ],
+      "nameExplicit": false,
+      "name": "url_metadata_gist_pkey",
+      "schema": "public",
+      "table": "url_metadata_gist",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "post_id"
+      ],
+      "nameExplicit": false,
+      "name": "url_metadata_post_pkey",
+      "schema": "public",
+      "table": "url_metadata_post",
+      "entityType": "pks"
+    }
+  ],
+  "renames": []
+}

--- a/packages/db/src/relations.ts
+++ b/packages/db/src/relations.ts
@@ -65,5 +65,17 @@ export const relations = defineRelations(schema, (r) => ({
 			from: r.profiles.slug.through(r.collectionAuthors.authorSlug),
 			to: r.collections.slug.through(r.collectionAuthors.collectionSlug),
 		}),
+		achievements: r.many.profileAchievements({
+			from: r.profiles.slug,
+			to: r.profileAchievements.profileSlug,
+		}),
+	},
+
+	// Profile achievements relation
+	profileAchievements: {
+		profile: r.one.profiles({
+			from: r.profileAchievements.profileSlug,
+			to: r.profiles.slug,
+		}),
 	},
 }));

--- a/packages/db/src/schema/profiles.ts
+++ b/packages/db/src/schema/profiles.ts
@@ -1,4 +1,10 @@
-import { pgTable, timestamp, jsonb, text } from "drizzle-orm/pg-core";
+import {
+	pgTable,
+	timestamp,
+	jsonb,
+	text,
+	primaryKey,
+} from "drizzle-orm/pg-core";
 
 export const profiles = pgTable("profiles", {
 	slug: text("slug").primaryKey(),
@@ -10,3 +16,19 @@ export const profiles = pgTable("profiles", {
 		.$default(() => new Date()),
 	meta: jsonb("meta").notNull(),
 });
+
+export const profileAchievements = pgTable(
+	"profile_achievements",
+	{
+		profileSlug: text("profile_slug")
+			.notNull()
+			.references(() => profiles.slug, { onDelete: "cascade" }),
+		achievementId: text("achievement_id").notNull(),
+		grantedAt: timestamp("granted_at", { withTimezone: true })
+			.notNull()
+			.$default(() => new Date()),
+	},
+	(table) => [
+		primaryKey({ columns: [table.profileSlug, table.achievementId] }),
+	],
+);

--- a/packages/github-api/src/contributorYears.ts
+++ b/packages/github-api/src/contributorYears.ts
@@ -1,0 +1,12 @@
+// All calendar years from FIRST_CONTRIBUTOR_YEAR through the current year.
+// A year is included in the contributor achievement only when the author had
+// actual GitHub activity that year — it is not granted to everyone for every year.
+export const FIRST_CONTRIBUTOR_YEAR = 2019;
+
+export function contributorYears(): number[] {
+	const years: number[] = [];
+	for (let y = FIRST_CONTRIBUTOR_YEAR; y <= new Date().getFullYear(); y++) {
+		years.push(y);
+	}
+	return years;
+}

--- a/packages/github-api/src/getAuthorGitHubStats.ts
+++ b/packages/github-api/src/getAuthorGitHubStats.ts
@@ -63,7 +63,8 @@ export async function getAuthorGitHubStats(
 	if (!env.GITHUB_TOKEN) return undefined;
 
 	const userResult = (await client.graphql<Record<string, { id: string }>>(
-		`query { user(login: "${githubLogin}") { id } }`,
+		`query($login: String!) { user(login: $login) { id } }`,
+		{ login: githubLogin },
 	)) as Record<string, { id: string }>;
 
 	const userId = userResult?.user?.id;

--- a/packages/github-api/src/getAuthorGitHubStats.ts
+++ b/packages/github-api/src/getAuthorGitHubStats.ts
@@ -1,20 +1,11 @@
 import { client } from "./client.ts";
 import { env } from "@playfulprogramming/common";
+import { contributorYears } from "./contributorYears.ts";
 
 export interface AuthorGitHubStats {
 	issueCount: number;
 	pullRequestCount: number;
 	commitsInYear: number[];
-}
-
-const FIRST_CONTRIBUTOR_YEAR = 2019;
-
-function contributorYears(): number[] {
-	const years: number[] = [];
-	for (let y = FIRST_CONTRIBUTOR_YEAR; y <= new Date().getFullYear(); y++) {
-		years.push(y);
-	}
-	return years;
 }
 
 const years = contributorYears();

--- a/packages/github-api/src/getAuthorGitHubStats.ts
+++ b/packages/github-api/src/getAuthorGitHubStats.ts
@@ -1,0 +1,88 @@
+import { client } from "./client.ts";
+import { env } from "@playfulprogramming/common";
+
+export interface AuthorGitHubStats {
+	issueCount: number;
+	pullRequestCount: number;
+	commitsInYear: number[];
+}
+
+const FIRST_CONTRIBUTOR_YEAR = 2019;
+
+function contributorYears(): number[] {
+	const years: number[] = [];
+	for (let y = FIRST_CONTRIBUTOR_YEAR; y <= new Date().getFullYear(); y++) {
+		years.push(y);
+	}
+	return years;
+}
+
+const years = contributorYears();
+
+// Mirrors the GraphQL query used in the playfulprogramming frontend at build time.
+// Fetches total issues opened, PRs opened, and which calendar years had ≥1 commit.
+const statsQuery = `
+query($login: String, $id: ID, $prSearch: String!) {
+  repository(owner: "${env.GITHUB_REPO_OWNER}", name: "${env.GITHUB_REPO_NAME}") {
+    defaultBranchRef {
+      target {
+        ... on Commit {
+          ${years
+						.map(
+							(year) => `
+          history${year}: history(
+            first: 1
+            since: "${year}-01-01T00:00:00.000Z"
+            until: "${year + 1}-01-01T00:00:00.000Z"
+            author: { id: $id }
+          ) { totalCount }`,
+						)
+						.join("")}
+        }
+      }
+    }
+    issues(filterBy: { createdBy: $login }) { totalCount }
+  }
+  search(query: $prSearch, type: ISSUE) { issueCount }
+}
+`;
+
+type StatsResponse = {
+	repository: {
+		defaultBranchRef: {
+			target: Record<string, { totalCount: number }>;
+		};
+		issues: { totalCount: number };
+	};
+	search: { issueCount: number };
+};
+
+export async function getAuthorGitHubStats(
+	githubLogin: string,
+): Promise<AuthorGitHubStats | undefined> {
+	if (!env.GITHUB_TOKEN) return undefined;
+
+	const userResult = (await client.graphql<Record<string, { id: string }>>(
+		`query { user(login: "${githubLogin}") { id } }`,
+	)) as Record<string, { id: string }>;
+
+	const userId = userResult?.user?.id;
+	if (!userId) return undefined;
+
+	const response = await client.graphql<StatsResponse>(statsQuery, {
+		login: githubLogin,
+		id: userId,
+		prSearch: `repo:${env.GITHUB_REPO_OWNER}/${env.GITHUB_REPO_NAME} is:pr author:${githubLogin}`,
+	});
+
+	const commitTarget = response.repository.defaultBranchRef.target;
+	const commitsInYear = years.filter(
+		(year) => (commitTarget[`history${year}`]?.totalCount ?? 0) > 0,
+	);
+
+	return {
+		issueCount: response.repository.issues.totalCount,
+		pullRequestCount: response.search.issueCount,
+		commitsInYear,
+	};
+}

--- a/packages/github-api/src/index.ts
+++ b/packages/github-api/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./contributorYears.ts";
 export * from "./getAuthorGitHubStats.ts";
 export * from "./getCommits.ts";
 export * from "./getContents.ts";

--- a/packages/github-api/src/index.ts
+++ b/packages/github-api/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./getAuthorGitHubStats.ts";
 export * from "./getCommits.ts";
 export * from "./getContents.ts";
 export * from "./getContentsRaw.ts";


### PR DESCRIPTION
## Summary

Adds a system for tracking and surfacing author achievements:

- New `profile_achievements` table (drizzle migration `20260620230617_thankful_angel`) storing manual and auto-computed achievements per author.
- New `grant-author-achievements` worker task that evaluates GitHub/content-stat-based achievement rules (post count, word count, co-authorship, collection count, GitHub stats) and writes the earned set, leaving manually-granted achievements untouched.
- `sync-author`, `sync-collection`, and `sync-post` processors now enqueue a `grant-author-achievements` job (deduped by author slug) whenever an author's profile, collection, or post is synced.
- Manual achievement IDs continue to come from author frontmatter (`achievements` field) and are persisted in the same table.
- New `getAuthorGitHubStats` helper in `@playfulprogramming/github-api` for fetching GitHub-derived stats (requires `GITHUB_TOKEN`, documented in `.env.example`).
- New `GET` authors route exposing achievement data (with a fixed display map for names/descriptions) for the frontend.

Closes #97

## Reviewer notes

- `apps/worker/src/createWorker.ts` also has unrelated changes in my working tree (a Windows ESM-compatibility fix for `import.meta.resolve`, plus a `stalled` event handler) — intentionally **excluded** from this PR and will land separately.
- New env var: `GITHUB_TOKEN` (optional, only needed for GitHub-based achievement calculation) — documented in `.env.example`.

## Test plan

- [ ] Run worker locally, sync an author/post/collection, confirm a `grant-author-achievements` job is enqueued and achievements are written to `profile_achievements`
- [ ] Confirm manual achievements (from author frontmatter) survive re-runs of the auto-grant job
- [ ] Hit the new authors route and confirm achievement display data looks correct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an author achievements system with automatic badge granting from author content metrics and optional GitHub activity, alongside manually granted achievements.
  * Added/extended an author details endpoint to return the author profile with their granted achievements.
  * Updated post, collection, and author sync flows to automatically refresh achievements when related data changes.
* **Chores**
  * Added database storage and ORM relations for granted achievements.
  * Updated the environment template with an optional GitHub token to enable GitHub-based calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->