### PR TITLE
fix(worker): resolve processor path as URL for Windows ESM compatibility

### DIFF
--- a/apps/worker/src/createWorker.ts
+++ b/apps/worker/src/createWorker.ts
@@ -6,9 +6,7 @@ export function createWorker<T extends TasksValues>(
 	task: T,
 	processor: string,
 ): Worker {
-	const processorFile = import.meta
-		.resolve(processor)
-		.replace(/^file:\/\//, "");
+	const processorFile = new URL(import.meta.resolve(processor));
 	const worker = new Worker(task, processorFile, {
 		connection: redis as never,
 		concurrency: 2,
@@ -35,6 +33,10 @@ export function createWorker<T extends TasksValues>(
 			{ id: job?.id, data: job?.data },
 			job?.stacktrace,
 		);
+	});
+
+	worker.on("stalled", (jobId) => {
+		console.warn("Job stalled:", { task, jobId });
 	});
 
 	return worker;


### PR DESCRIPTION
## What broke

On Windows, `createWorker` failed to resolve task processor files. `import.meta.resolve(processor)` returns a `file://` URL, and the old code stripped the scheme with a plain string replace (`.replace(/^file:\/\//, "")`). On Windows that leaves a path like `/C:/projects/.../processor.ts` — a leading slash in front of the drive letter — which BullMQ/Node can't open as a filesystem path. The same code works fine on POSIX systems, which is why it went unnoticed until running the worker on Windows.

## Fix

Wrap the resolved URL in `new URL(...)` instead of manually stripping the scheme, and pass that to `Worker`. BullMQ/Node accept a `URL` object directly and handle the platform-specific path conversion correctly, so this works on both Windows and POSIX.

## Related improvement

Also adds a `worker.on("stalled", ...)` handler that logs a warning when a job stalls. This isn't part of the Windows fix itself, but came out of the same investigation into worker behavior and is small enough to include here rather than open a separate PR.

Fixes #170