### PR TITLE
feat(api): add post_tags and collection_tags join tables

### DIFF
--- a/apps/worker/src/tasks/sync-collection/processor.test.ts
+++ b/apps/worker/src/tasks/sync-collection/processor.test.ts
@@ -5,6 +5,7 @@ import {
 	collections,
 	collectionAuthors,
 	collectionData,
+	collectionTags,
 	db,
 } from "@playfulprogramming/db";
 import { s3 } from "@playfulprogramming/s3";
@@ -22,6 +23,7 @@ test("Creates an example collection successfully", async () => {
 		onConflictDoUpdate: vi.fn(),
 	});
 	const insertAuthorValues = vi.fn();
+	const insertTagsValues = vi.fn();
 	vi.mocked(db.insert).mockImplementation((table) => {
 		if (table === collections) {
 			return { values: insertCollectionValues } as never;
@@ -31,6 +33,9 @@ test("Creates an example collection successfully", async () => {
 		}
 		if (table === collectionAuthors) {
 			return { values: insertAuthorValues } as never;
+		}
+		if (table === collectionTags) {
+			return { values: insertTagsValues } as never;
 		}
 		throw new Error(`Unexpected table: ${table}`);
 	});
@@ -72,6 +77,9 @@ title: "Example Collection"
 description: "A test collection"
 coverImg: "./cover.png"
 published: "2023-01-01T00:00:00Z"
+tags:
+  - javascript
+  - tutorial
 ---
 `,
 				status: 200,
@@ -122,7 +130,7 @@ published: "2023-01-01T00:00:00Z"
 		socialImage: null,
 		meta: {
 			buttons: undefined,
-			tags: undefined,
+			tags: ["javascript", "tutorial"],
 			chapterList: undefined,
 		},
 	});
@@ -135,6 +143,21 @@ published: "2023-01-01T00:00:00Z"
 		{
 			collectionSlug: "example-collection",
 			authorSlug: "example-author",
+		},
+	]);
+
+	// The tag association was deleted and re-inserted
+	expect(deleteWhere).toBeCalledWith(
+		eq(collectionTags.collectionSlug, "example-collection"),
+	);
+	expect(insertTagsValues).toBeCalledWith([
+		{
+			collectionSlug: "example-collection",
+			tag: "javascript",
+		},
+		{
+			collectionSlug: "example-collection",
+			tag: "tutorial",
 		},
 	]);
 });
@@ -364,6 +387,117 @@ published: "2023-01-01T00:00:00Z"
 		{
 			collectionSlug: "example-collection",
 			authorSlug: "example-author",
+		},
+	]);
+});
+
+test("Handles collection with multiple tags", async () => {
+	const insertCollectionValues = vi.fn().mockReturnValue({
+		onConflictDoNothing: vi.fn(),
+	});
+	const insertCollectionDataValues = vi.fn().mockReturnValue({
+		onConflictDoUpdate: vi.fn(),
+	});
+	const insertAuthorValues = vi.fn();
+	const insertTagsValues = vi.fn();
+	vi.mocked(db.insert).mockImplementation((table) => {
+		if (table === collections) {
+			return { values: insertCollectionValues } as never;
+		}
+		if (table === collectionData) {
+			return { values: insertCollectionDataValues } as never;
+		}
+		if (table === collectionAuthors) {
+			return { values: insertAuthorValues } as never;
+		}
+		if (table === collectionTags) {
+			return { values: insertTagsValues } as never;
+		}
+		throw new Error(`Unexpected table: ${table}`);
+	});
+
+	const deleteWhere = vi.fn();
+	vi.mocked(db.delete).mockReturnValue({
+		where: deleteWhere,
+	} as never);
+
+	vi.mocked(github.getContents).mockImplementation(((params: {
+		path: string;
+	}) => {
+		if (
+			params.path === "/content/example-author/collections/example-collection/"
+		) {
+			return Promise.resolve({
+				data: {
+					entries: [
+						{
+							name: "index.md",
+							path: "content/example-author/collections/example-collection/index.md",
+						},
+					],
+				},
+				status: 200,
+			});
+		}
+		return Promise.reject();
+	}) as never);
+
+	vi.mocked(github.getContentsRaw).mockImplementation((params) => {
+		if (
+			params.path ===
+			"/content/example-author/collections/example-collection/index.md"
+		) {
+			return Promise.resolve({
+				data: `---
+title: "Example Collection"
+description: "A test collection"
+coverImg: "./cover.png"
+published: "2023-01-01T00:00:00Z"
+tags:
+  - javascript
+  - tutorial
+---
+`,
+				status: 200,
+			});
+		}
+		return Promise.reject();
+	});
+
+	vi.mocked(github.getContentsRawStream).mockImplementation((params) => {
+		if (
+			params.path ===
+			"/content/example-author/collections/example-collection/cover.png"
+		) {
+			const buffer = Buffer.from(mockImage, "base64");
+			return Promise.resolve({
+				data: Readable.toWeb(Readable.from(buffer)) as never,
+				status: 200,
+			});
+		}
+		return Promise.reject();
+	});
+
+	await processor({
+		data: {
+			author: "example-author",
+			collection: "example-collection",
+			ref: "main",
+		},
+	} as unknown as Job<TaskInputs["sync-collection"]>);
+
+	// Both tags should be inserted, and the old association deleted first
+	expect(deleteWhere).toBeCalledWith(
+		eq(collectionTags.collectionSlug, "example-collection"),
+	);
+	expect(insertTagsValues).toBeCalledWith([
+		{
+			collectionSlug: "example-collection",
+			tag: "javascript",
+		},
+		{
+			collectionSlug: "example-collection",
+			tag: "tutorial",
 		},
 	]);
 });

--- a/apps/worker/src/tasks/sync-collection/processor.test.ts
+++ b/apps/worker/src/tasks/sync-collection/processor.test.ts
@@ -391,7 +391,7 @@ published: "2023-01-01T00:00:00Z"
 	]);
 });
 
-test("Handles collection with multiple tags", async () => {
+test("Replaces tags when synced again with a different tag set", async () => {
 	const insertCollectionValues = vi.fn().mockReturnValue({
 		onConflictDoNothing: vi.fn(),
 	});
@@ -442,6 +442,21 @@ test("Handles collection with multiple tags", async () => {
 		return Promise.reject();
 	}) as never);
 
+	vi.mocked(github.getContentsRawStream).mockImplementation((params) => {
+		if (
+			params.path ===
+			"/content/example-author/collections/example-collection/cover.png"
+		) {
+			const buffer = Buffer.from(mockImage, "base64");
+			return Promise.resolve({
+				data: Readable.toWeb(Readable.from(buffer)) as never,
+				status: 200,
+			});
+		}
+		return Promise.reject();
+	});
+
+	// First sync: original tag set
 	vi.mocked(github.getContentsRaw).mockImplementation((params) => {
 		if (
 			params.path ===
@@ -464,14 +479,44 @@ tags:
 		return Promise.reject();
 	});
 
-	vi.mocked(github.getContentsRawStream).mockImplementation((params) => {
+	await processor({
+		data: {
+			author: "example-author",
+			collection: "example-collection",
+			ref: "main",
+		},
+	} as unknown as Job<TaskInputs["sync-collection"]>);
+
+	expect(insertTagsValues).toBeCalledWith([
+		{
+			collectionSlug: "example-collection",
+			tag: "javascript",
+		},
+		{
+			collectionSlug: "example-collection",
+			tag: "tutorial",
+		},
+	]);
+
+	insertTagsValues.mockClear();
+	deleteWhere.mockClear();
+
+	// Second sync: a different tag set
+	vi.mocked(github.getContentsRaw).mockImplementation((params) => {
 		if (
 			params.path ===
-			"/content/example-author/collections/example-collection/cover.png"
+			"/content/example-author/collections/example-collection/index.md"
 		) {
-			const buffer = Buffer.from(mockImage, "base64");
 			return Promise.resolve({
-				data: Readable.toWeb(Readable.from(buffer)) as never,
+				data: `---
+title: "Example Collection"
+description: "A test collection"
+coverImg: "./cover.png"
+published: "2023-01-01T00:00:00Z"
+tags:
+  - rust
+---
+`,
 				status: 200,
 			});
 		}
@@ -486,18 +531,170 @@ tags:
 		},
 	} as unknown as Job<TaskInputs["sync-collection"]>);
 
-	// Both tags should be inserted, and the old association deleted first
+	// Old tags were deleted and only the new tag set remains
 	expect(deleteWhere).toBeCalledWith(
 		eq(collectionTags.collectionSlug, "example-collection"),
 	);
 	expect(insertTagsValues).toBeCalledWith([
 		{
 			collectionSlug: "example-collection",
+			tag: "rust",
+		},
+	]);
+	expect(insertTagsValues).not.toBeCalledWith(
+		expect.arrayContaining([expect.objectContaining({ tag: "javascript" })]),
+	);
+	expect(insertTagsValues).not.toBeCalledWith(
+		expect.arrayContaining([expect.objectContaining({ tag: "tutorial" })]),
+	);
+});
+
+test("Unions tags across all locales", async () => {
+	const insertCollectionValues = vi.fn().mockReturnValue({
+		onConflictDoNothing: vi.fn(),
+	});
+	const insertCollectionDataValues = vi.fn().mockReturnValue({
+		onConflictDoUpdate: vi.fn(),
+	});
+	const insertAuthorValues = vi.fn();
+	const insertTagsValues = vi.fn();
+	vi.mocked(db.insert).mockImplementation((table) => {
+		if (table === collections) {
+			return { values: insertCollectionValues } as never;
+		}
+		if (table === collectionData) {
+			return { values: insertCollectionDataValues } as never;
+		}
+		if (table === collectionAuthors) {
+			return { values: insertAuthorValues } as never;
+		}
+		if (table === collectionTags) {
+			return { values: insertTagsValues } as never;
+		}
+		throw new Error(`Unexpected table: ${table}`);
+	});
+
+	const deleteCollectionAuthorsWhere = vi.fn();
+	const deleteCollectionTagsWhere = vi.fn();
+	vi.mocked(db.delete).mockImplementation((table) => {
+		if (table === collectionAuthors) {
+			return { where: deleteCollectionAuthorsWhere } as never;
+		}
+		if (table === collectionTags) {
+			return { where: deleteCollectionTagsWhere } as never;
+		}
+		throw new Error(`Unexpected table: ${table}`);
+	});
+
+	// Return folder listing with both index.md and index.es.md
+	vi.mocked(github.getContents).mockImplementation(((params: {
+		path: string;
+	}) => {
+		if (
+			params.path ===
+			"/content/example-author/collections/multilang-tags-collection/"
+		) {
+			return Promise.resolve({
+				data: {
+					entries: [
+						{
+							name: "index.md",
+							path: "content/example-author/collections/multilang-tags-collection/index.md",
+						},
+						{
+							name: "index.es.md",
+							path: "content/example-author/collections/multilang-tags-collection/index.es.md",
+						},
+					],
+				},
+				status: 200,
+			});
+		}
+		return Promise.reject();
+	}) as never);
+
+	vi.mocked(github.getContentsRaw).mockImplementation((params) => {
+		if (
+			params.path ===
+			"/content/example-author/collections/multilang-tags-collection/index.md"
+		) {
+			return Promise.resolve({
+				data: `---
+title: "English Collection"
+description: "A test collection"
+coverImg: "./cover.png"
+published: "2023-01-01T00:00:00Z"
+tags:
+  - javascript
+  - tutorial
+---
+`,
+				status: 200,
+			});
+		}
+		if (
+			params.path ===
+			"/content/example-author/collections/multilang-tags-collection/index.es.md"
+		) {
+			return Promise.resolve({
+				data: `---
+title: "Colección en Español"
+description: "A test collection"
+coverImg: "./cover.png"
+published: "2023-01-01T00:00:00Z"
+tags:
+  - espanol
+---
+`,
+				status: 200,
+			});
+		}
+		return Promise.reject();
+	});
+
+	vi.mocked(github.getContentsRawStream).mockImplementation((params) => {
+		if (
+			params.path ===
+			"/content/example-author/collections/multilang-tags-collection/cover.png"
+		) {
+			const buffer = Buffer.from(mockImage, "base64");
+			return Promise.resolve({
+				data: Readable.toWeb(Readable.from(buffer)) as never,
+				status: 200,
+			});
+		}
+		return Promise.reject();
+	});
+
+	await processor({
+		data: {
+			author: "example-author",
+			collection: "multilang-tags-collection",
+			ref: "main",
+		},
+	} as unknown as Job<TaskInputs["sync-collection"]>);
+
+	// Assert: tags from both locales are unioned and deduped in a single insert
+	expect(insertTagsValues).toBeCalledTimes(1);
+	expect(insertTagsValues).toBeCalledWith([
+		{
+			collectionSlug: "multilang-tags-collection",
 			tag: "javascript",
 		},
 		{
-			collectionSlug: "example-collection",
+			collectionSlug: "multilang-tags-collection",
 			tag: "tutorial",
 		},
+		{
+			collectionSlug: "multilang-tags-collection",
+			tag: "espanol",
+		},
 	]);
+
+	// Assert: the tags delete ran once (not once per locale, unlike author associations)
+	expect(deleteCollectionTagsWhere).toBeCalledTimes(1);
+	expect(deleteCollectionTagsWhere).toBeCalledWith(
+		eq(collectionTags.collectionSlug, "multilang-tags-collection"),
+	);
+	expect(deleteCollectionAuthorsWhere).toBeCalledTimes(2);
 });

--- a/apps/worker/src/tasks/sync-collection/processor.ts
+++ b/apps/worker/src/tasks/sync-collection/processor.ts
@@ -97,6 +97,8 @@ export default createProcessor(
 			[] as Array<{ entry: Entry; locale: string }>,
 		);
 
+		const allTags = new Set<string>();
+
 		// Check if coverImg or socialImg have changed since last edit, if so upload to S3
 		for (const { entry, locale } of collectionEntries) {
 			const contentUrl = new URL(entry.path, "http://localhost");
@@ -117,6 +119,10 @@ export default createProcessor(
 
 			const { data } = matter(contentResponse.data);
 			const collectionParsedData = Value.Parse(CollectionMetaSchema, data);
+
+			if (collectionParsedData.tags) {
+				collectionParsedData.tags.forEach((tag) => allTags.add(tag));
+			}
 
 			let coverImgKey: string | null = null;
 			let socialImgKey: string | null = null;
@@ -216,22 +222,26 @@ export default createProcessor(
 						})),
 					);
 				}
-
-				// Delete existing tag associations for this collection
-				await tx
-					.delete(collectionTags)
-					.where(eq(collectionTags.collectionSlug, collectionId));
-
-				// Insert new tag associations
-				if (collectionParsedData.tags && collectionParsedData.tags.length > 0) {
-					await tx.insert(collectionTags).values(
-						collectionParsedData.tags.map((tag) => ({
-							collectionSlug: collectionId,
-							tag,
-						})),
-					);
-				}
 			});
 		}
+
+		const tags = [...allTags];
+
+		await db.transaction(async (tx) => {
+			// Delete existing tag associations for this collection
+			await tx
+				.delete(collectionTags)
+				.where(eq(collectionTags.collectionSlug, collectionId));
+
+			// Insert new tag associations
+			if (tags.length > 0) {
+				await tx.insert(collectionTags).values(
+					tags.map((tag) => ({
+						collectionSlug: collectionId,
+						tag,
+					})),
+				);
+			}
+		});
 	},
 );

--- a/apps/worker/src/tasks/sync-collection/processor.ts
+++ b/apps/worker/src/tasks/sync-collection/processor.ts
@@ -4,6 +4,7 @@ import {
 	collectionAuthors,
 	collectionData,
 	collections,
+	collectionTags,
 	db,
 } from "@playfulprogramming/db";
 import * as github from "@playfulprogramming/github-api";
@@ -212,6 +213,21 @@ export default createProcessor(
 						authorSlugs.map((authorSlug) => ({
 							collectionSlug: collectionId,
 							authorSlug,
+						})),
+					);
+				}
+
+				// Delete existing tag associations for this collection
+				await tx
+					.delete(collectionTags)
+					.where(eq(collectionTags.collectionSlug, collectionId));
+
+				// Insert new tag associations
+				if (collectionParsedData.tags && collectionParsedData.tags.length > 0) {
+					await tx.insert(collectionTags).values(
+						collectionParsedData.tags.map((tag) => ({
+							collectionSlug: collectionId,
+							tag,
 						})),
 					);
 				}

--- a/apps/worker/src/tasks/sync-post/processor.test.ts
+++ b/apps/worker/src/tasks/sync-post/processor.test.ts
@@ -1,7 +1,13 @@
 import processor from "./processor.ts";
 import type { TaskInputs } from "@playfulprogramming/bullmq";
 import type { Job } from "bullmq";
-import { posts, postData, postAuthors, db } from "@playfulprogramming/db";
+import {
+	posts,
+	postData,
+	postAuthors,
+	postTags,
+	db,
+} from "@playfulprogramming/db";
 import { s3 } from "@playfulprogramming/s3";
 import * as github from "@playfulprogramming/github-api";
 import { eq } from "drizzle-orm";
@@ -14,6 +20,7 @@ test("Syncs a standalone post successfully", async () => {
 		onConflictDoUpdate: vi.fn(),
 	});
 	const insertPostAuthorsValues = vi.fn();
+	const insertPostTagsValues = vi.fn();
 
 	vi.mocked(db.insert).mockImplementation((table) => {
 		if (table === posts) {
@@ -24,6 +31,9 @@ test("Syncs a standalone post successfully", async () => {
 		}
 		if (table === postAuthors) {
 			return { values: insertPostAuthorsValues } as never;
+		}
+		if (table === postTags) {
+			return { values: insertPostTagsValues } as never;
 		}
 		throw new Error(`Unexpected table: ${table}`);
 	});
@@ -119,6 +129,19 @@ This is the post content.
 		{
 			postSlug: "example-post",
 			authorSlug: "example-author",
+		},
+	]);
+
+	// Assert: Old tags deleted, new tags inserted
+	expect(deleteWhere).toBeCalledWith(eq(postTags.postSlug, "example-post"));
+	expect(insertPostTagsValues).toBeCalledWith([
+		{
+			postSlug: "example-post",
+			tag: "javascript",
+		},
+		{
+			postSlug: "example-post",
+			tag: "tutorial",
 		},
 	]);
 });
@@ -526,6 +549,122 @@ authors:
 		{
 			postSlug: "collab-post",
 			authorSlug: "co-author",
+		},
+	]);
+});
+
+test("Unions tags across all locales", async () => {
+	const insertPostsValues = vi.fn().mockReturnValue({
+		onConflictDoNothing: vi.fn(),
+	});
+	const insertPostDataValues = vi.fn().mockReturnValue({
+		onConflictDoUpdate: vi.fn(),
+	});
+	const insertPostAuthorsValues = vi.fn();
+	const insertPostTagsValues = vi.fn();
+
+	vi.mocked(db.insert).mockImplementation((table) => {
+		if (table === posts) {
+			return { values: insertPostsValues } as never;
+		}
+		if (table === postData) {
+			return { values: insertPostDataValues } as never;
+		}
+		if (table === postAuthors) {
+			return { values: insertPostAuthorsValues } as never;
+		}
+		if (table === postTags) {
+			return { values: insertPostTagsValues } as never;
+		}
+		throw new Error(`Unexpected table: ${table}`);
+	});
+
+	const deleteWhere = vi.fn();
+	vi.mocked(db.delete).mockReturnValue({
+		where: deleteWhere,
+	} as never);
+
+	// Return folder listing with both index.md and index.es.md
+	vi.mocked(github.getContents).mockImplementation(((params: {
+		path: string;
+	}) => {
+		if (params.path === "/content/example-author/posts/multilang-tags-post/") {
+			return Promise.resolve({
+				data: {
+					entries: [
+						{
+							name: "index.md",
+							path: "content/example-author/posts/multilang-tags-post/index.md",
+						},
+						{
+							name: "index.es.md",
+							path: "content/example-author/posts/multilang-tags-post/index.es.md",
+						},
+					],
+				},
+				status: 200,
+			});
+		}
+		return Promise.reject(new Error(`Unexpected path: ${params.path}`));
+	}) as never);
+
+	vi.mocked(github.getContentsRaw).mockImplementation((params) => {
+		if (
+			params.path ===
+			"/content/example-author/posts/multilang-tags-post/index.md"
+		) {
+			return Promise.resolve({
+				data: `---
+title: "English Post"
+published: "2024-01-15T00:00:00Z"
+tags:
+  - javascript
+  - tutorial
+---
+`,
+				status: 200,
+			});
+		}
+		if (
+			params.path ===
+			"/content/example-author/posts/multilang-tags-post/index.es.md"
+		) {
+			return Promise.resolve({
+				data: `---
+title: "Post en Español"
+published: "2024-01-15T00:00:00Z"
+tags:
+  - tutorial
+  - espanol
+---
+`,
+				status: 200,
+			});
+		}
+		return Promise.reject(new Error(`Unexpected path: ${params.path}`));
+	});
+
+	await processor({
+		data: {
+			author: "example-author",
+			post: "multilang-tags-post",
+			ref: "main",
+		},
+	} as unknown as Job<TaskInputs["sync-post"]>);
+
+	// Assert: Tags from both locales are unioned, with duplicates deduped
+	expect(insertPostTagsValues).toBeCalledWith([
+		{
+			postSlug: "multilang-tags-post",
+			tag: "javascript",
+		},
+		{
+			postSlug: "multilang-tags-post",
+			tag: "tutorial",
+		},
+		{
+			postSlug: "multilang-tags-post",
+			tag: "espanol",
 		},
 	]);
 });

--- a/apps/worker/src/tasks/sync-post/processor.ts
+++ b/apps/worker/src/tasks/sync-post/processor.ts
@@ -1,6 +1,12 @@
 import { env } from "@playfulprogramming/common";
 import { Tasks } from "@playfulprogramming/bullmq";
-import { db, posts, postData, postAuthors } from "@playfulprogramming/db";
+import {
+	db,
+	posts,
+	postData,
+	postAuthors,
+	postTags,
+} from "@playfulprogramming/db";
 import * as github from "@playfulprogramming/github-api";
 import { s3 } from "@playfulprogramming/s3";
 import { createProcessor } from "../../createProcessor.ts";
@@ -70,6 +76,7 @@ export default createProcessor(Tasks.SYNC_POST, async (job, { signal }) => {
 	// Phase 1: Collect all data from GitHub
 	// =========================================================================
 	const allAuthorSlugs = new Set<string>([author]);
+	const allTags = new Set<string>();
 
 	const localeData = await Promise.all(
 		localeFiles.map(async (file) => {
@@ -98,6 +105,10 @@ export default createProcessor(Tasks.SYNC_POST, async (job, { signal }) => {
 				parsed.authors.forEach((a) => allAuthorSlugs.add(a));
 			}
 
+			if (parsed.tags) {
+				parsed.tags.forEach((t) => allTags.add(t));
+			}
+
 			// If the description is missing, populate it from the content
 			parsed.description ??= extractMarkdownExcerpt(content, 150);
 			// calculate a (very) approximate word count
@@ -108,6 +119,7 @@ export default createProcessor(Tasks.SYNC_POST, async (job, { signal }) => {
 	);
 
 	const authorSlugs = [...allAuthorSlugs];
+	const tags = [...allTags];
 
 	// =========================================================================
 	// Phase 2: Upload all markdown to S3
@@ -181,5 +193,16 @@ export default createProcessor(Tasks.SYNC_POST, async (job, { signal }) => {
 				authorSlug,
 			})),
 		);
+
+		await tx.delete(postTags).where(eq(postTags.postSlug, post));
+
+		if (tags.length > 0) {
+			await tx.insert(postTags).values(
+				tags.map((tag) => ({
+					postSlug: post,
+					tag,
+				})),
+			);
+		}
 	});
 });

--- a/apps/worker/test-utils/setup.ts
+++ b/apps/worker/test-utils/setup.ts
@@ -73,6 +73,10 @@ vi.mock("@playfulprogramming/db", () => {
 			collectionSlug: {},
 			authorSlug: {},
 		},
+		collectionTags: {
+			collectionSlug: {},
+			tag: {},
+		},
 		postData: {
 			slug: {},
 			locale: {},
@@ -81,6 +85,10 @@ vi.mock("@playfulprogramming/db", () => {
 		postAuthors: {
 			postSlug: {},
 			authorSlug: {},
+		},
+		postTags: {
+			postSlug: {},
+			tag: {},
 		},
 		collectionChapters: {
 			postSlug: {},

--- a/packages/db/drizzle/20260703143803_famous_puma/migration.sql
+++ b/packages/db/drizzle/20260703143803_famous_puma/migration.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "collection_tags" (
+	"collection_slug" text,
+	"tag" text,
+	CONSTRAINT "collection_tags_pkey" PRIMARY KEY("collection_slug","tag")
+);
+--> statement-breakpoint
+CREATE TABLE "post_tags" (
+	"post_slug" text,
+	"tag" text,
+	CONSTRAINT "post_tags_pkey" PRIMARY KEY("post_slug","tag")
+);
+--> statement-breakpoint
+ALTER TABLE "collection_tags" ADD CONSTRAINT "collection_tags_collection_slug_collections_slug_fkey" FOREIGN KEY ("collection_slug") REFERENCES "collections"("slug") ON DELETE CASCADE;--> statement-breakpoint
+ALTER TABLE "post_tags" ADD CONSTRAINT "post_tags_post_slug_posts_slug_fkey" FOREIGN KEY ("post_slug") REFERENCES "posts"("slug") ON DELETE CASCADE;

--- a/packages/db/drizzle/20260703143803_famous_puma/snapshot.json
+++ b/packages/db/drizzle/20260703143803_famous_puma/snapshot.json
@@ -1,0 +1,1539 @@
+{
+  "version": "8",
+  "dialect": "postgres",
+  "id": "e66fa34b-90bc-4916-a2b3-3c783ad69266",
+  "prevIds": [
+    "60f31ba8-78b9-4d1c-a249-b89ecc397df9"
+  ],
+  "ddl": [
+    {
+      "isRlsEnabled": false,
+      "name": "profiles",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "collection_authors",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "collection_data",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "collections",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "post_authors",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "post_data",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "posts",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "post_images",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "url_metadata",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "url_metadata_gist",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "url_metadata_gist_file",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "url_metadata_post",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "collection_tags",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "post_tags",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "''",
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "profile_image",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profiles"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "published_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profiles"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "meta",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "collection_slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_authors"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "author_slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_authors"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "locale",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "''",
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "published_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "meta",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "cover_image",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "social_image",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collections"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "post_slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_authors"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "author_slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_authors"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "locale",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "''",
+      "generated": null,
+      "identity": null,
+      "name": "version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "''",
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "word_count",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "social_image",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "banner_image",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "original_link",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "noindex",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "edited_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "published_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "meta",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "collection_slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "collection_order",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_images"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "banner_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_images"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "link_preview_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_images"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "index_md5",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_images"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "fetched_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_images"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "error",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_images"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "url",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "icon_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "icon_width",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "icon_height",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "banner_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "banner_width",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "banner_height",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "gist_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "post_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "embed_src",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "embed_width",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "embed_height",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "embed_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "fetched_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "error",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "gist_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_gist"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "username",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_gist"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_gist"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "gist_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_gist_file"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "filename",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_gist_file"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "content_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_gist_file"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "language",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_gist_file"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "post_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "author_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "author_handle",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "content",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "url",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "avatar_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "avatar_width",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "avatar_height",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image_width",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image_height",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image_alt_text",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "num_likes",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "num_reposts",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "num_replies",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "collection_slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_tags"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "tag",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_tags"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "post_slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_tags"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "tag",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_tags"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "collection_slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "collections",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "collection_authors_collection_slug_collections_slug_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "collection_authors"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "author_slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "profiles",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "collection_authors_author_slug_profiles_slug_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "collection_authors"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "collections",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "collection_data_slug_collections_slug_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "post_slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "posts",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "post_authors_post_slug_posts_slug_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "post_authors"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "author_slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "profiles",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "post_authors_author_slug_profiles_slug_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "post_authors"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "posts",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "post_data_slug_posts_slug_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "collection_slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "collections",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "name": "posts_collection_slug_collections_slug_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "gist_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "url_metadata_gist",
+      "columnsTo": [
+        "gist_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "name": "url_metadata_gist_id_url_metadata_gist_gist_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "post_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "url_metadata_post",
+      "columnsTo": [
+        "post_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "name": "url_metadata_post_id_url_metadata_post_post_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "gist_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "url_metadata_gist",
+      "columnsTo": [
+        "gist_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "url_metadata_gist_file_gist_id_url_metadata_gist_gist_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "url_metadata_gist_file"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "collection_slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "collections",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "collection_tags_collection_slug_collections_slug_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "collection_tags"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "post_slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "posts",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "post_tags_post_slug_posts_slug_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "post_tags"
+    },
+    {
+      "columns": [
+        "collection_slug",
+        "author_slug"
+      ],
+      "nameExplicit": false,
+      "name": "collection_authors_collection_slug_author_slug_pk",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "collection_authors"
+    },
+    {
+      "columns": [
+        "slug",
+        "locale"
+      ],
+      "nameExplicit": false,
+      "name": "collection_data_slug_locale_pk",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "columns": [
+        "post_slug",
+        "author_slug"
+      ],
+      "nameExplicit": false,
+      "name": "post_authors_post_slug_author_slug_pk",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "post_authors"
+    },
+    {
+      "columns": [
+        "slug",
+        "locale",
+        "version"
+      ],
+      "nameExplicit": false,
+      "name": "post_data_slug_locale_version_pk",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "columns": [
+        "gist_id",
+        "filename"
+      ],
+      "nameExplicit": false,
+      "name": "url_metadata_gist_file_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "url_metadata_gist_file"
+    },
+    {
+      "columns": [
+        "collection_slug",
+        "tag"
+      ],
+      "nameExplicit": false,
+      "name": "collection_tags_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "collection_tags"
+    },
+    {
+      "columns": [
+        "post_slug",
+        "tag"
+      ],
+      "nameExplicit": false,
+      "name": "post_tags_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "post_tags"
+    },
+    {
+      "columns": [
+        "slug"
+      ],
+      "nameExplicit": false,
+      "name": "profiles_pkey",
+      "schema": "public",
+      "table": "profiles",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "slug"
+      ],
+      "nameExplicit": false,
+      "name": "collections_pkey",
+      "schema": "public",
+      "table": "collections",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "slug"
+      ],
+      "nameExplicit": false,
+      "name": "posts_pkey",
+      "schema": "public",
+      "table": "posts",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "slug"
+      ],
+      "nameExplicit": false,
+      "name": "post_images_pkey",
+      "schema": "public",
+      "table": "post_images",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "url"
+      ],
+      "nameExplicit": false,
+      "name": "url_metadata_pkey",
+      "schema": "public",
+      "table": "url_metadata",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "gist_id"
+      ],
+      "nameExplicit": false,
+      "name": "url_metadata_gist_pkey",
+      "schema": "public",
+      "table": "url_metadata_gist",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "post_id"
+      ],
+      "nameExplicit": false,
+      "name": "url_metadata_post_pkey",
+      "schema": "public",
+      "table": "url_metadata_post",
+      "entityType": "pks"
+    }
+  ],
+  "renames": []
+}

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -3,3 +3,4 @@ export * from "./collections.ts";
 export * from "./posts.ts";
 export * from "./post-images.ts";
 export * from "./url-metadata.ts";
+export * from "./tags.ts";

--- a/packages/db/src/schema/tags.ts
+++ b/packages/db/src/schema/tags.ts
@@ -1,0 +1,35 @@
+import { pgTable, text, primaryKey } from "drizzle-orm/pg-core";
+import { posts } from "./posts.ts";
+import { collections } from "./collections.ts";
+
+export const postTags = pgTable(
+	"post_tags",
+	{
+		postSlug: text("post_slug")
+			.notNull()
+			.references(() => posts.slug, {
+				onDelete: "cascade",
+			}),
+		tag: text("tag").notNull(),
+	},
+	(table) => [
+		primaryKey({
+			columns: [table.postSlug, table.tag],
+		}),
+	],
+);
+
+export const collectionTags = pgTable(
+	"collection_tags",
+	{
+		collectionSlug: text("collection_slug")
+			.notNull()
+			.references(() => collections.slug, { onDelete: "cascade" }),
+		tag: text("tag").notNull(),
+	},
+	(table) => [
+		primaryKey({
+			columns: [table.collectionSlug, table.tag],
+		}),
+	],
+);


### PR DESCRIPTION
## Summary
Implements #81 per James's clarification: instead of a central tags table, this adds two simple join tables that store the tag directly as text.

- `packages/db/src/schema/tags.ts` — `post_tags` (composite PK `postSlug, tag`) and `collection_tags` (composite PK `collectionSlug, tag`), mirroring the existing `postAuthors`/`collectionAuthors` pattern (cascade delete on the parent slug).
- `sync-post` processor: tags aren't localized, so it unions the tag set across all locale frontmatter entries (same approach as `allAuthorSlugs`), then does a single delete-then-insert into `post_tags` inside the existing transaction.
- `sync-collection` processor: mirrors the existing per-locale `collectionAuthors` delete-then-insert, using that iteration's parsed `tags`.
- The existing `meta.tags` JSONB field on `post_data`/`collection_data` is left untouched — the join tables are additive, nothing reads from them yet.

## Test plan
- [x] `pnpm test:unit` (lint, knip, publint, sherif, vitest — 24 targets across 11 projects)
- [x] `pnpm prettier --check .`
- [x] Generated migration applied locally and verified table/FK shape via `psql \d`
- [x] New/updated processor tests cover: tag insert on sync, tag union across multiple locales (sync-post), and per-collection tag replacement (sync-collection)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tags are now saved for both posts and collections.
  * When syncing, tags from multiple locales are combined and deduplicated.
* **Bug Fixes**
  * Existing tag associations are replaced during sync, so outdated tags no longer remain.
  * Tag associations are automatically removed when the related post or collection is deleted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->