### PR TITLE
fix(db): resolve migrate.ts migrations path for Windows ESM compatibility

### DIFF
--- a/packages/db/scripts/migrate.ts
+++ b/packages/db/scripts/migrate.ts
@@ -1,9 +1,8 @@
+import { fileURLToPath } from "node:url";
 import { migrate } from "drizzle-orm/node-postgres/migrator";
 import { db } from "../src/client.ts";
 
-const migrationsFolder = import.meta
-	.resolve("../drizzle")
-	.replace(/^file:\/\//, "");
+const migrationsFolder = fileURLToPath(new URL("../drizzle", import.meta.url));
 console.log(`Running migrations from ${migrationsFolder}`);
 
 await migrate(db, {


### PR DESCRIPTION
## Summary
Third occurrence of the same Windows/ESM `import.meta.resolve()` bug as `drizzle.config.ts` (#166) and `createWorker.ts` (#171): `import.meta.resolve()` returns a `file:///C:/...` URL string on Windows, and manually stripping the `file://` prefix leaves an invalid path (`/C:/...`) instead of a real filesystem path — causing `readdirSync`/`path.join` to fail with `ENOENT`.

Found while working on #81, unrelated to that PR's scope.

Unlike the prior two fixes, this uses `fileURLToPath(new URL(...))` rather than passing a bare `URL` object directly to the consumer — drizzle-orm's `migrate()` calls `path.join()` on `migrationsFolder` internally, which requires a string, not a `URL` instance.

## Test plan
- [x] `pnpm test:unit` (24 targets across 11 projects)
- [x] `pnpm prettier --check .`
- [x] Ran `packages/db/scripts/migrate.ts` directly on Windows and confirmed it resolves to a correct native path (`C:\...`) and runs migrations without error