### PR TITLE
feat: sync post attachments (images, PDFs, PowerPoints) to S3

### DIFF
--- a/apps/worker/src/tasks/sync-post/processor.test.ts
+++ b/apps/worker/src/tasks/sync-post/processor.test.ts
@@ -881,10 +881,12 @@ published: "2024-01-15T00:00:00Z"
 		"application/pdf",
 	);
 
-	// Assert: Top-level image attachment resized and converted, key normalized to .jpeg
+	// Assert: Top-level image attachment resized and converted; ".jpeg" is appended
+	// after the original filename (not replacing its extension) to avoid same-basename
+	// collisions between files with different source extensions
 	expect(s3.upload).toBeCalledWith(
 		"example-bucket",
-		"posts/attachment-post/attachments/banner.jpeg",
+		"posts/attachment-post/attachments/banner.png.jpeg",
 		undefined,
 		expect.anything(),
 		"image/jpeg",
@@ -893,13 +895,15 @@ published: "2024-01-15T00:00:00Z"
 	// Assert: Image nested in a subfolder was discovered via recursion
 	expect(s3.upload).toBeCalledWith(
 		"example-bucket",
-		"posts/attachment-post/attachments/diagrams/chart.jpeg",
+		"posts/attachment-post/attachments/diagrams/chart.png.jpeg",
 		undefined,
 		expect.anything(),
 		"image/jpeg",
 	);
 
-	// Assert: Attachment rows saved with resized image dimensions, null for non-images
+	// Assert: Attachment rows saved with resized image dimensions, null for non-images.
+	// The 1x1 fixture is already smaller than the max size, so withoutEnlargement
+	// keeps it at 1x1 instead of upscaling it.
 	expect(insertPostAttachmentsValues).toBeCalledWith([
 		{
 			postSlug: "attachment-post",
@@ -911,16 +915,17 @@ published: "2024-01-15T00:00:00Z"
 		{
 			postSlug: "attachment-post",
 			attachmentName: "banner.png",
-			attachmentKey: "posts/attachment-post/attachments/banner.jpeg",
-			width: 2048,
-			height: 2048,
+			attachmentKey: "posts/attachment-post/attachments/banner.png.jpeg",
+			width: 1,
+			height: 1,
 		},
 		{
 			postSlug: "attachment-post",
 			attachmentName: "diagrams/chart.png",
-			attachmentKey: "posts/attachment-post/attachments/diagrams/chart.jpeg",
-			width: 2048,
-			height: 2048,
+			attachmentKey:
+				"posts/attachment-post/attachments/diagrams/chart.png.jpeg",
+			width: 1,
+			height: 1,
 		},
 	]);
 });
@@ -977,6 +982,15 @@ test("Diffs post attachments: skips unchanged, re-uploads changed, removes delet
 										attachmentName: "changed.txt",
 										attachmentKey: "posts/diffing-post/attachments/changed.txt",
 									},
+									{
+										// Simulates an attachment whose stored key no longer matches
+										// what the current key-naming scheme would produce (e.g. a
+										// prior scheme version) - exercises the "delete old key
+										// before uploading under the new key" path.
+										attachmentName: "moved.txt",
+										attachmentKey:
+											"posts/diffing-post/attachments/legacy/moved.txt",
+									},
 								]
 							: [],
 					),
@@ -984,12 +998,17 @@ test("Diffs post attachments: skips unchanged, re-uploads changed, removes delet
 			}) as never,
 	);
 
+	// Only "unchanged.txt" reports as matching in S3 - everything else is treated
+	// as changed content.
 	vi.mocked(s3.matchesEtag).mockImplementation(((
 		_bucket: string,
 		key: string,
 	) => Promise.resolve(key.endsWith("unchanged.txt"))) as never);
+	// Only the stale "moved.txt" key still exists in S3 under its old path.
 	vi.mocked(s3.exists).mockImplementation(((_bucket: string, key: string) =>
-		Promise.resolve(key.endsWith("changed.txt"))) as never);
+		Promise.resolve(
+			key === "posts/diffing-post/attachments/legacy/moved.txt",
+		)) as never);
 
 	const basePath = "/content/example-author/posts/diffing-post/";
 	const baseFolderPath = "content/example-author/posts/diffing-post/";
@@ -1014,6 +1033,11 @@ test("Diffs post attachments: skips unchanged, re-uploads changed, removes delet
 						{
 							name: "changed.txt",
 							path: `${baseFolderPath}changed.txt`,
+							type: "file",
+						},
+						{
+							name: "moved.txt",
+							path: `${baseFolderPath}moved.txt`,
 							type: "file",
 						},
 					],
@@ -1055,6 +1079,14 @@ published: "2024-01-15T00:00:00Z"
 				status: 200,
 			});
 		}
+		if (params.path === `/${baseFolderPath}moved.txt`) {
+			return Promise.resolve({
+				data: Readable.toWeb(
+					Readable.from(Buffer.from("moved content")),
+				) as never,
+				status: 200,
+			});
+		}
 		return Promise.reject(new Error(`Unexpected path: ${params.path}`));
 	});
 
@@ -1072,16 +1104,28 @@ published: "2024-01-15T00:00:00Z"
 		"posts/diffing-post/attachments/old-file.txt",
 	);
 
-	// Assert: changed attachment's old object was removed before re-upload
-	expect(s3.remove).toBeCalledWith(
+	// Assert: changed attachment keeps the same key, so it's overwritten directly
+	// by s3.upload rather than deleted first
+	expect(s3.remove).not.toBeCalledWith(
 		"example-bucket",
 		"posts/diffing-post/attachments/changed.txt",
 	);
-
-	// Assert: changed attachment was re-uploaded
 	expect(s3.upload).toBeCalledWith(
 		"example-bucket",
 		"posts/diffing-post/attachments/changed.txt",
+		undefined,
+		expect.anything(),
+		"text/plain",
+	);
+
+	// Assert: moved attachment's stale key was removed before uploading under the new key
+	expect(s3.remove).toBeCalledWith(
+		"example-bucket",
+		"posts/diffing-post/attachments/legacy/moved.txt",
+	);
+	expect(s3.upload).toBeCalledWith(
+		"example-bucket",
+		"posts/diffing-post/attachments/moved.txt",
 		undefined,
 		expect.anything(),
 		"text/plain",
@@ -1091,12 +1135,12 @@ published: "2024-01-15T00:00:00Z"
 	expect(s3.upload).not.toBeCalledWith(
 		"example-bucket",
 		"posts/diffing-post/attachments/unchanged.txt",
-		expect.anything(),
+		undefined,
 		expect.anything(),
 		expect.anything(),
 	);
 
-	// Assert: only the two attachments still present in the repo are saved
+	// Assert: only the three attachments still present in the repo are saved
 	expect(insertPostAttachmentsValues).toBeCalledWith([
 		{
 			postSlug: "diffing-post",
@@ -1109,6 +1153,13 @@ published: "2024-01-15T00:00:00Z"
 			postSlug: "diffing-post",
 			attachmentName: "changed.txt",
 			attachmentKey: "posts/diffing-post/attachments/changed.txt",
+			width: null,
+			height: null,
+		},
+		{
+			postSlug: "diffing-post",
+			attachmentName: "moved.txt",
+			attachmentKey: "posts/diffing-post/attachments/moved.txt",
 			width: null,
 			height: null,
 		},

--- a/apps/worker/src/tasks/sync-post/processor.test.ts
+++ b/apps/worker/src/tasks/sync-post/processor.test.ts
@@ -828,13 +828,13 @@ published: "2024-01-15T00:00:00Z"
 	});
 
 	vi.mocked(github.getContentsRawStream).mockImplementation((params) => {
-		if (params.path === `/${baseFolderPath}notes.pdf`) {
+		if (params.path === `${baseFolderPath}notes.pdf`) {
 			return Promise.resolve({
 				data: Readable.toWeb(Readable.from(Buffer.from("PDF-DATA"))) as never,
 				status: 200,
 			});
 		}
-		if (params.path === `/${baseFolderPath}banner.png`) {
+		if (params.path === `${baseFolderPath}banner.png`) {
 			return Promise.resolve({
 				data: Readable.toWeb(
 					Readable.from(Buffer.from(ONE_PIXEL_PNG_BASE64, "base64")),
@@ -892,6 +892,116 @@ published: "2024-01-15T00:00:00Z"
 			height: 1,
 		},
 	]);
+});
+
+test("Passes attachment paths to GitHub unchanged, without URL-encoding special characters", async () => {
+	const insertPostsValues = vi.fn().mockReturnValue({
+		onConflictDoNothing: vi.fn(),
+	});
+	const insertPostDataValues = vi.fn().mockReturnValue({
+		onConflictDoUpdate: vi.fn(),
+	});
+	const insertPostAuthorsValues = vi.fn();
+	const insertPostAttachmentsValues = vi.fn();
+
+	vi.mocked(db.insert).mockImplementation((table) => {
+		if (table === posts) {
+			return { values: insertPostsValues } as never;
+		}
+		if (table === postData) {
+			return { values: insertPostDataValues } as never;
+		}
+		if (table === postAuthors) {
+			return { values: insertPostAuthorsValues } as never;
+		}
+		if (table === postAttachments) {
+			return { values: insertPostAttachmentsValues } as never;
+		}
+		throw new Error(`Unexpected table: ${table}`);
+	});
+
+	const deleteWhere = vi.fn();
+	vi.mocked(db.delete).mockReturnValue({
+		where: deleteWhere,
+	} as never);
+
+	vi.mocked(db.select).mockReturnValue({
+		from: vi.fn().mockReturnValue({
+			where: vi.fn().mockResolvedValue([]),
+		}),
+	} as never);
+
+	const basePath = "/content/example-author/posts/special-chars-post/";
+	const baseFolderPath = "content/example-author/posts/special-chars-post/";
+	// A filename with a space and a "#" - naively round-tripping this through
+	// `new URL()` would percent-encode the space and treat "#" as a fragment
+	// delimiter, truncating the path GitHub actually receives.
+	const attachmentName = "my notes #1.txt";
+
+	vi.mocked(github.getContents).mockImplementation(((params: {
+		path: string;
+	}) => {
+		if (params.path === basePath) {
+			return Promise.resolve({
+				data: {
+					entries: [
+						{
+							name: "index.md",
+							path: `${baseFolderPath}index.md`,
+							type: "file",
+							sha: "index-sha",
+						},
+						{
+							name: attachmentName,
+							path: `${baseFolderPath}${attachmentName}`,
+							type: "file",
+							sha: "notes-sha",
+						},
+					],
+				},
+				status: 200,
+			});
+		}
+		return Promise.reject(new Error(`Unexpected path: ${params.path}`));
+	}) as never);
+
+	vi.mocked(github.getContentsRaw).mockImplementation((params) => {
+		if (params.path === `/${baseFolderPath}index.md`) {
+			return Promise.resolve({
+				data: `---
+title: "Special Chars Post"
+published: "2024-01-15T00:00:00Z"
+---
+`,
+				status: 200,
+			});
+		}
+		return Promise.reject(new Error(`Unexpected path: ${params.path}`));
+	});
+
+	vi.mocked(github.getContentsRawStream).mockImplementation((params) => {
+		if (params.path === `${baseFolderPath}${attachmentName}`) {
+			return Promise.resolve({
+				data: Readable.toWeb(Readable.from(Buffer.from("notes"))) as never,
+				status: 200,
+			});
+		}
+		return Promise.reject(new Error(`Unexpected path: ${params.path}`));
+	});
+
+	await processor({
+		data: {
+			author: "example-author",
+			post: "special-chars-post",
+			ref: "main",
+		},
+	} as unknown as Job<TaskInputs["sync-post"]>);
+
+	// Assert: the raw entry path (with its space and "#" intact) was passed
+	// straight through to getContentsRawStream, unencoded
+	expect(github.getContentsRawStream).toBeCalledWith(
+		expect.objectContaining({ path: `${baseFolderPath}${attachmentName}` }),
+	);
 });
 
 test("Diffs post attachments: skips unchanged sha, re-uploads changed sha under a new key, removes deleted", async () => {
@@ -1014,7 +1124,7 @@ published: "2024-01-15T00:00:00Z"
 	});
 
 	vi.mocked(github.getContentsRawStream).mockImplementation((params) => {
-		if (params.path === `/${baseFolderPath}changed.txt`) {
+		if (params.path === `${baseFolderPath}changed.txt`) {
 			return Promise.resolve({
 				data: Readable.toWeb(
 					Readable.from(Buffer.from("new content")),
@@ -1051,6 +1161,26 @@ published: "2024-01-15T00:00:00Z"
 		undefined,
 		expect.anything(),
 		"text/plain",
+	);
+
+	// Assert: the new object is uploaded before the old one is removed, so a
+	// failed upload can't leave the persisted row pointing at a deleted key
+	const newKeyUploadOrder = vi
+		.mocked(s3.upload)
+		.mock.calls.findIndex(
+			(call) =>
+				call[1] === "posts/diffing-post/attachments/new-changed-sha.txt",
+		);
+	const oldKeyRemoveOrder = vi
+		.mocked(s3.remove)
+		.mock.calls.findIndex(
+			(call) =>
+				call[1] === "posts/diffing-post/attachments/old-changed-sha.txt",
+		);
+	expect(
+		vi.mocked(s3.upload).mock.invocationCallOrder[newKeyUploadOrder],
+	).toBeLessThan(
+		vi.mocked(s3.remove).mock.invocationCallOrder[oldKeyRemoveOrder],
 	);
 
 	// Assert: unchanged attachment was NOT re-uploaded or removed
@@ -1195,7 +1325,7 @@ published: "2024-01-15T00:00:00Z"
 	// Assert: the attachment's content was never fetched from GitHub, since its
 	// sha already matched the stored row
 	expect(github.getContentsRawStream).not.toBeCalledWith(
-		expect.objectContaining({ path: `/${baseFolderPath}unchanged.txt` }),
+		expect.objectContaining({ path: `${baseFolderPath}unchanged.txt` }),
 	);
 
 	// Assert: no S3 interaction happened for the attachment itself (content.md

--- a/apps/worker/src/tasks/sync-post/processor.test.ts
+++ b/apps/worker/src/tasks/sync-post/processor.test.ts
@@ -6,11 +6,16 @@ import {
 	postData,
 	postAuthors,
 	postTags,
+	postAttachments,
 	db,
 } from "@playfulprogramming/db";
 import { s3 } from "@playfulprogramming/s3";
 import * as github from "@playfulprogramming/github-api";
 import { eq } from "drizzle-orm";
+import { Readable } from "node:stream";
+
+const ONE_PIXEL_PNG_BASE64 =
+	"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR42mMAAQAABQABoIJXOQAAAABJRU5ErkJggg==";
 
 test("Syncs a standalone post successfully", async () => {
 	const insertPostsValues = vi.fn().mockReturnValue({
@@ -242,16 +247,25 @@ test("Deletes a post record if it no longer exists", async () => {
 		where: deleteWhere,
 	} as never);
 
-	vi.mocked(db.select).mockReturnValue({
-		from: vi.fn().mockReturnValue({
-			where: vi
-				.fn()
-				.mockResolvedValue([
-					{ authorSlug: "example-author" },
-					{ authorSlug: "co-author" },
-				]),
-		}),
-	} as never);
+	vi.mocked(db.select).mockImplementation(
+		() =>
+			({
+				from: vi.fn((table: unknown) => ({
+					where: vi.fn().mockResolvedValue(
+						table === postAttachments
+							? [
+									{
+										attachmentKey: "posts/example-post/attachments/notes.pdf",
+									},
+									{
+										attachmentKey: "posts/example-post/attachments/banner.jpeg",
+									},
+								]
+							: [{ authorSlug: "example-author" }, { authorSlug: "co-author" }],
+					),
+				})),
+			}) as never,
+	);
 
 	// Mock GitHub: return 404
 	vi.mocked(github.getContents).mockImplementation(((params: {
@@ -274,6 +288,16 @@ test("Deletes a post record if it no longer exists", async () => {
 			ref: "main",
 		},
 	} as unknown as Job<TaskInputs["sync-post"]>);
+
+	// Assert: Post's attachments were removed from S3 before the cascading delete
+	expect(s3.remove).toBeCalledWith(
+		"example-bucket",
+		"posts/example-post/attachments/notes.pdf",
+	);
+	expect(s3.remove).toBeCalledWith(
+		"example-bucket",
+		"posts/example-post/attachments/banner.jpeg",
+	);
 
 	// Assert: Post was deleted from posts table (cascade handles related tables)
 	expect(db.delete).toBeCalledWith(posts);
@@ -712,6 +736,381 @@ tags:
 		{
 			postSlug: "multilang-tags-post",
 			tag: "espanol",
+		},
+	]);
+});
+
+test("Uploads post attachments, resizing images and recursing into subfolders", async () => {
+	const insertPostsValues = vi.fn().mockReturnValue({
+		onConflictDoNothing: vi.fn(),
+	});
+	const insertPostDataValues = vi.fn().mockReturnValue({
+		onConflictDoUpdate: vi.fn(),
+	});
+	const insertPostAuthorsValues = vi.fn();
+	const insertPostAttachmentsValues = vi.fn();
+
+	vi.mocked(db.insert).mockImplementation((table) => {
+		if (table === posts) {
+			return { values: insertPostsValues } as never;
+		}
+		if (table === postData) {
+			return { values: insertPostDataValues } as never;
+		}
+		if (table === postAuthors) {
+			return { values: insertPostAuthorsValues } as never;
+		}
+		if (table === postAttachments) {
+			return { values: insertPostAttachmentsValues } as never;
+		}
+		throw new Error(`Unexpected table: ${table}`);
+	});
+
+	const deleteWhere = vi.fn();
+	vi.mocked(db.delete).mockReturnValue({
+		where: deleteWhere,
+	} as never);
+
+	vi.mocked(db.select).mockReturnValue({
+		from: vi.fn().mockReturnValue({
+			where: vi.fn().mockResolvedValue([]),
+		}),
+	} as never);
+
+	const basePath = "/content/example-author/posts/attachment-post/";
+	const baseFolderPath = "content/example-author/posts/attachment-post/";
+
+	vi.mocked(github.getContents).mockImplementation(((params: {
+		path: string;
+	}) => {
+		if (params.path === basePath) {
+			return Promise.resolve({
+				data: {
+					entries: [
+						{
+							name: "index.md",
+							path: `${baseFolderPath}index.md`,
+							type: "file",
+						},
+						{
+							name: "notes.pdf",
+							path: `${baseFolderPath}notes.pdf`,
+							type: "file",
+						},
+						{
+							name: "banner.png",
+							path: `${baseFolderPath}banner.png`,
+							type: "file",
+						},
+						{
+							name: "diagrams",
+							path: `${baseFolderPath}diagrams`,
+							type: "dir",
+						},
+					],
+				},
+				status: 200,
+			});
+		}
+		if (params.path === `/${baseFolderPath}diagrams/`) {
+			return Promise.resolve({
+				data: {
+					entries: [
+						{
+							name: "chart.png",
+							path: `${baseFolderPath}diagrams/chart.png`,
+							type: "file",
+						},
+					],
+				},
+				status: 200,
+			});
+		}
+		return Promise.reject(new Error(`Unexpected path: ${params.path}`));
+	}) as never);
+
+	vi.mocked(github.getContentsRaw).mockImplementation((params) => {
+		if (params.path === `/${baseFolderPath}index.md`) {
+			return Promise.resolve({
+				data: `---
+title: "Attachment Post"
+published: "2024-01-15T00:00:00Z"
+---
+`,
+				status: 200,
+			});
+		}
+		return Promise.reject(new Error(`Unexpected path: ${params.path}`));
+	});
+
+	vi.mocked(github.getContentsRawStream).mockImplementation((params) => {
+		if (params.path === `/${baseFolderPath}notes.pdf`) {
+			return Promise.resolve({
+				data: Readable.toWeb(Readable.from(Buffer.from("PDF-DATA"))) as never,
+				status: 200,
+			});
+		}
+		if (
+			params.path === `/${baseFolderPath}banner.png` ||
+			params.path === `/${baseFolderPath}diagrams/chart.png`
+		) {
+			return Promise.resolve({
+				data: Readable.toWeb(
+					Readable.from(Buffer.from(ONE_PIXEL_PNG_BASE64, "base64")),
+				) as never,
+				status: 200,
+			});
+		}
+		return Promise.reject(new Error(`Unexpected path: ${params.path}`));
+	});
+
+	await processor({
+		data: {
+			author: "example-author",
+			post: "attachment-post",
+			ref: "main",
+		},
+	} as unknown as Job<TaskInputs["sync-post"]>);
+
+	// Assert: Non-image attachment uploaded as-is under its original extension
+	expect(s3.upload).toBeCalledWith(
+		"example-bucket",
+		"posts/attachment-post/attachments/notes.pdf",
+		undefined,
+		expect.anything(),
+		"application/pdf",
+	);
+
+	// Assert: Top-level image attachment resized and converted, key normalized to .jpeg
+	expect(s3.upload).toBeCalledWith(
+		"example-bucket",
+		"posts/attachment-post/attachments/banner.jpeg",
+		undefined,
+		expect.anything(),
+		"image/jpeg",
+	);
+
+	// Assert: Image nested in a subfolder was discovered via recursion
+	expect(s3.upload).toBeCalledWith(
+		"example-bucket",
+		"posts/attachment-post/attachments/diagrams/chart.jpeg",
+		undefined,
+		expect.anything(),
+		"image/jpeg",
+	);
+
+	// Assert: Attachment rows saved with resized image dimensions, null for non-images
+	expect(insertPostAttachmentsValues).toBeCalledWith([
+		{
+			postSlug: "attachment-post",
+			attachmentName: "notes.pdf",
+			attachmentKey: "posts/attachment-post/attachments/notes.pdf",
+			width: null,
+			height: null,
+		},
+		{
+			postSlug: "attachment-post",
+			attachmentName: "banner.png",
+			attachmentKey: "posts/attachment-post/attachments/banner.jpeg",
+			width: 2048,
+			height: 2048,
+		},
+		{
+			postSlug: "attachment-post",
+			attachmentName: "diagrams/chart.png",
+			attachmentKey: "posts/attachment-post/attachments/diagrams/chart.jpeg",
+			width: 2048,
+			height: 2048,
+		},
+	]);
+});
+
+test("Diffs post attachments: skips unchanged, re-uploads changed, removes deleted", async () => {
+	const insertPostsValues = vi.fn().mockReturnValue({
+		onConflictDoNothing: vi.fn(),
+	});
+	const insertPostDataValues = vi.fn().mockReturnValue({
+		onConflictDoUpdate: vi.fn(),
+	});
+	const insertPostAuthorsValues = vi.fn();
+	const insertPostAttachmentsValues = vi.fn();
+
+	vi.mocked(db.insert).mockImplementation((table) => {
+		if (table === posts) {
+			return { values: insertPostsValues } as never;
+		}
+		if (table === postData) {
+			return { values: insertPostDataValues } as never;
+		}
+		if (table === postAuthors) {
+			return { values: insertPostAuthorsValues } as never;
+		}
+		if (table === postAttachments) {
+			return { values: insertPostAttachmentsValues } as never;
+		}
+		throw new Error(`Unexpected table: ${table}`);
+	});
+
+	const deleteWhere = vi.fn();
+	vi.mocked(db.delete).mockReturnValue({
+		where: deleteWhere,
+	} as never);
+
+	vi.mocked(db.select).mockImplementation(
+		() =>
+			({
+				from: vi.fn((table: unknown) => ({
+					where: vi.fn().mockResolvedValue(
+						table === postAttachments
+							? [
+									{
+										attachmentName: "old-file.txt",
+										attachmentKey:
+											"posts/diffing-post/attachments/old-file.txt",
+									},
+									{
+										attachmentName: "unchanged.txt",
+										attachmentKey:
+											"posts/diffing-post/attachments/unchanged.txt",
+									},
+									{
+										attachmentName: "changed.txt",
+										attachmentKey: "posts/diffing-post/attachments/changed.txt",
+									},
+								]
+							: [],
+					),
+				})),
+			}) as never,
+	);
+
+	vi.mocked(s3.matchesEtag).mockImplementation(((
+		_bucket: string,
+		key: string,
+	) => Promise.resolve(key.endsWith("unchanged.txt"))) as never);
+	vi.mocked(s3.exists).mockImplementation(((_bucket: string, key: string) =>
+		Promise.resolve(key.endsWith("changed.txt"))) as never);
+
+	const basePath = "/content/example-author/posts/diffing-post/";
+	const baseFolderPath = "content/example-author/posts/diffing-post/";
+
+	vi.mocked(github.getContents).mockImplementation(((params: {
+		path: string;
+	}) => {
+		if (params.path === basePath) {
+			return Promise.resolve({
+				data: {
+					entries: [
+						{
+							name: "index.md",
+							path: `${baseFolderPath}index.md`,
+							type: "file",
+						},
+						{
+							name: "unchanged.txt",
+							path: `${baseFolderPath}unchanged.txt`,
+							type: "file",
+						},
+						{
+							name: "changed.txt",
+							path: `${baseFolderPath}changed.txt`,
+							type: "file",
+						},
+					],
+				},
+				status: 200,
+			});
+		}
+		return Promise.reject(new Error(`Unexpected path: ${params.path}`));
+	}) as never);
+
+	vi.mocked(github.getContentsRaw).mockImplementation((params) => {
+		if (params.path === `/${baseFolderPath}index.md`) {
+			return Promise.resolve({
+				data: `---
+title: "Diffing Post"
+published: "2024-01-15T00:00:00Z"
+---
+`,
+				status: 200,
+			});
+		}
+		return Promise.reject(new Error(`Unexpected path: ${params.path}`));
+	});
+
+	vi.mocked(github.getContentsRawStream).mockImplementation((params) => {
+		if (params.path === `/${baseFolderPath}unchanged.txt`) {
+			return Promise.resolve({
+				data: Readable.toWeb(
+					Readable.from(Buffer.from("same content")),
+				) as never,
+				status: 200,
+			});
+		}
+		if (params.path === `/${baseFolderPath}changed.txt`) {
+			return Promise.resolve({
+				data: Readable.toWeb(
+					Readable.from(Buffer.from("new content")),
+				) as never,
+				status: 200,
+			});
+		}
+		return Promise.reject(new Error(`Unexpected path: ${params.path}`));
+	});
+
+	await processor({
+		data: {
+			author: "example-author",
+			post: "diffing-post",
+			ref: "main",
+		},
+	} as unknown as Job<TaskInputs["sync-post"]>);
+
+	// Assert: attachment no longer in the repo was removed from S3
+	expect(s3.remove).toBeCalledWith(
+		"example-bucket",
+		"posts/diffing-post/attachments/old-file.txt",
+	);
+
+	// Assert: changed attachment's old object was removed before re-upload
+	expect(s3.remove).toBeCalledWith(
+		"example-bucket",
+		"posts/diffing-post/attachments/changed.txt",
+	);
+
+	// Assert: changed attachment was re-uploaded
+	expect(s3.upload).toBeCalledWith(
+		"example-bucket",
+		"posts/diffing-post/attachments/changed.txt",
+		undefined,
+		expect.anything(),
+		"text/plain",
+	);
+
+	// Assert: unchanged attachment was NOT re-uploaded
+	expect(s3.upload).not.toBeCalledWith(
+		"example-bucket",
+		"posts/diffing-post/attachments/unchanged.txt",
+		expect.anything(),
+		expect.anything(),
+		expect.anything(),
+	);
+
+	// Assert: only the two attachments still present in the repo are saved
+	expect(insertPostAttachmentsValues).toBeCalledWith([
+		{
+			postSlug: "diffing-post",
+			attachmentName: "unchanged.txt",
+			attachmentKey: "posts/diffing-post/attachments/unchanged.txt",
+			width: null,
+			height: null,
+		},
+		{
+			postSlug: "diffing-post",
+			attachmentName: "changed.txt",
+			attachmentKey: "posts/diffing-post/attachments/changed.txt",
+			width: null,
+			height: null,
 		},
 	]);
 });

--- a/apps/worker/src/tasks/sync-post/processor.test.ts
+++ b/apps/worker/src/tasks/sync-post/processor.test.ts
@@ -740,7 +740,7 @@ tags:
 	]);
 });
 
-test("Uploads post attachments, resizing images and recursing into subfolders", async () => {
+test("Uploads post attachments, resizing images and content-addressing their keys by sha", async () => {
 	const insertPostsValues = vi.fn().mockReturnValue({
 		onConflictDoNothing: vi.fn(),
 	});
@@ -791,35 +791,19 @@ test("Uploads post attachments, resizing images and recursing into subfolders", 
 							name: "index.md",
 							path: `${baseFolderPath}index.md`,
 							type: "file",
+							sha: "index-sha",
 						},
 						{
 							name: "notes.pdf",
 							path: `${baseFolderPath}notes.pdf`,
 							type: "file",
+							sha: "notes-sha",
 						},
 						{
 							name: "banner.png",
 							path: `${baseFolderPath}banner.png`,
 							type: "file",
-						},
-						{
-							name: "diagrams",
-							path: `${baseFolderPath}diagrams`,
-							type: "dir",
-						},
-					],
-				},
-				status: 200,
-			});
-		}
-		if (params.path === `/${baseFolderPath}diagrams/`) {
-			return Promise.resolve({
-				data: {
-					entries: [
-						{
-							name: "chart.png",
-							path: `${baseFolderPath}diagrams/chart.png`,
-							type: "file",
+							sha: "banner-sha",
 						},
 					],
 				},
@@ -850,10 +834,7 @@ published: "2024-01-15T00:00:00Z"
 				status: 200,
 			});
 		}
-		if (
-			params.path === `/${baseFolderPath}banner.png` ||
-			params.path === `/${baseFolderPath}diagrams/chart.png`
-		) {
+		if (params.path === `/${baseFolderPath}banner.png`) {
 			return Promise.resolve({
 				data: Readable.toWeb(
 					Readable.from(Buffer.from(ONE_PIXEL_PNG_BASE64, "base64")),
@@ -872,30 +853,19 @@ published: "2024-01-15T00:00:00Z"
 		},
 	} as unknown as Job<TaskInputs["sync-post"]>);
 
-	// Assert: Non-image attachment uploaded as-is under its original extension
+	// Assert: Non-image attachment uploaded as-is, keyed by its sha and original extension
 	expect(s3.upload).toBeCalledWith(
 		"example-bucket",
-		"posts/attachment-post/attachments/notes.pdf",
+		"posts/attachment-post/attachments/notes-sha.pdf",
 		undefined,
 		expect.anything(),
 		"application/pdf",
 	);
 
-	// Assert: Top-level image attachment resized and converted; ".jpeg" is appended
-	// after the original filename (not replacing its extension) to avoid same-basename
-	// collisions between files with different source extensions
+	// Assert: Image attachment resized and converted; key is the sha with a ".jpeg" extension
 	expect(s3.upload).toBeCalledWith(
 		"example-bucket",
-		"posts/attachment-post/attachments/banner.png.jpeg",
-		undefined,
-		expect.anything(),
-		"image/jpeg",
-	);
-
-	// Assert: Image nested in a subfolder was discovered via recursion
-	expect(s3.upload).toBeCalledWith(
-		"example-bucket",
-		"posts/attachment-post/attachments/diagrams/chart.png.jpeg",
+		"posts/attachment-post/attachments/banner-sha.jpeg",
 		undefined,
 		expect.anything(),
 		"image/jpeg",
@@ -908,29 +878,23 @@ published: "2024-01-15T00:00:00Z"
 		{
 			postSlug: "attachment-post",
 			attachmentName: "notes.pdf",
-			attachmentKey: "posts/attachment-post/attachments/notes.pdf",
+			attachmentKey: "posts/attachment-post/attachments/notes-sha.pdf",
+			sha: "notes-sha",
 			width: null,
 			height: null,
 		},
 		{
 			postSlug: "attachment-post",
 			attachmentName: "banner.png",
-			attachmentKey: "posts/attachment-post/attachments/banner.png.jpeg",
-			width: 1,
-			height: 1,
-		},
-		{
-			postSlug: "attachment-post",
-			attachmentName: "diagrams/chart.png",
-			attachmentKey:
-				"posts/attachment-post/attachments/diagrams/chart.png.jpeg",
+			attachmentKey: "posts/attachment-post/attachments/banner-sha.jpeg",
+			sha: "banner-sha",
 			width: 1,
 			height: 1,
 		},
 	]);
 });
 
-test("Diffs post attachments: skips unchanged, re-uploads changed, removes deleted", async () => {
+test("Diffs post attachments: skips unchanged sha, re-uploads changed sha under a new key, removes deleted", async () => {
 	const insertPostsValues = vi.fn().mockReturnValue({
 		onConflictDoNothing: vi.fn(),
 	});
@@ -971,25 +935,26 @@ test("Diffs post attachments: skips unchanged, re-uploads changed, removes delet
 									{
 										attachmentName: "old-file.txt",
 										attachmentKey:
-											"posts/diffing-post/attachments/old-file.txt",
+											"posts/diffing-post/attachments/old-file-sha.txt",
+										sha: "old-file-sha",
+										width: null,
+										height: null,
 									},
 									{
 										attachmentName: "unchanged.txt",
 										attachmentKey:
-											"posts/diffing-post/attachments/unchanged.txt",
+											"posts/diffing-post/attachments/unchanged-sha.txt",
+										sha: "unchanged-sha",
+										width: null,
+										height: null,
 									},
 									{
 										attachmentName: "changed.txt",
-										attachmentKey: "posts/diffing-post/attachments/changed.txt",
-									},
-									{
-										// Simulates an attachment whose stored key no longer matches
-										// what the current key-naming scheme would produce (e.g. a
-										// prior scheme version) - exercises the "delete old key
-										// before uploading under the new key" path.
-										attachmentName: "moved.txt",
 										attachmentKey:
-											"posts/diffing-post/attachments/legacy/moved.txt",
+											"posts/diffing-post/attachments/old-changed-sha.txt",
+										sha: "old-changed-sha",
+										width: null,
+										height: null,
 									},
 								]
 							: [],
@@ -997,18 +962,6 @@ test("Diffs post attachments: skips unchanged, re-uploads changed, removes delet
 				})),
 			}) as never,
 	);
-
-	// Only "unchanged.txt" reports as matching in S3 - everything else is treated
-	// as changed content.
-	vi.mocked(s3.matchesEtag).mockImplementation(((
-		_bucket: string,
-		key: string,
-	) => Promise.resolve(key.endsWith("unchanged.txt"))) as never);
-	// Only the stale "moved.txt" key still exists in S3 under its old path.
-	vi.mocked(s3.exists).mockImplementation(((_bucket: string, key: string) =>
-		Promise.resolve(
-			key === "posts/diffing-post/attachments/legacy/moved.txt",
-		)) as never);
 
 	const basePath = "/content/example-author/posts/diffing-post/";
 	const baseFolderPath = "content/example-author/posts/diffing-post/";
@@ -1024,21 +977,19 @@ test("Diffs post attachments: skips unchanged, re-uploads changed, removes delet
 							name: "index.md",
 							path: `${baseFolderPath}index.md`,
 							type: "file",
+							sha: "index-sha",
 						},
 						{
 							name: "unchanged.txt",
 							path: `${baseFolderPath}unchanged.txt`,
 							type: "file",
+							sha: "unchanged-sha",
 						},
 						{
 							name: "changed.txt",
 							path: `${baseFolderPath}changed.txt`,
 							type: "file",
-						},
-						{
-							name: "moved.txt",
-							path: `${baseFolderPath}moved.txt`,
-							type: "file",
+							sha: "new-changed-sha",
 						},
 					],
 				},
@@ -1063,26 +1014,10 @@ published: "2024-01-15T00:00:00Z"
 	});
 
 	vi.mocked(github.getContentsRawStream).mockImplementation((params) => {
-		if (params.path === `/${baseFolderPath}unchanged.txt`) {
-			return Promise.resolve({
-				data: Readable.toWeb(
-					Readable.from(Buffer.from("same content")),
-				) as never,
-				status: 200,
-			});
-		}
 		if (params.path === `/${baseFolderPath}changed.txt`) {
 			return Promise.resolve({
 				data: Readable.toWeb(
 					Readable.from(Buffer.from("new content")),
-				) as never,
-				status: 200,
-			});
-		}
-		if (params.path === `/${baseFolderPath}moved.txt`) {
-			return Promise.resolve({
-				data: Readable.toWeb(
-					Readable.from(Buffer.from("moved content")),
 				) as never,
 				status: 200,
 			});
@@ -1101,65 +1036,186 @@ published: "2024-01-15T00:00:00Z"
 	// Assert: attachment no longer in the repo was removed from S3
 	expect(s3.remove).toBeCalledWith(
 		"example-bucket",
-		"posts/diffing-post/attachments/old-file.txt",
+		"posts/diffing-post/attachments/old-file-sha.txt",
 	);
 
-	// Assert: changed attachment keeps the same key, so it's overwritten directly
-	// by s3.upload rather than deleted first
-	expect(s3.remove).not.toBeCalledWith(
-		"example-bucket",
-		"posts/diffing-post/attachments/changed.txt",
-	);
-	expect(s3.upload).toBeCalledWith(
-		"example-bucket",
-		"posts/diffing-post/attachments/changed.txt",
-		undefined,
-		expect.anything(),
-		"text/plain",
-	);
-
-	// Assert: moved attachment's stale key was removed before uploading under the new key
+	// Assert: changed attachment's old sha-keyed object was removed, and the
+	// new sha-keyed object was uploaded in its place
 	expect(s3.remove).toBeCalledWith(
 		"example-bucket",
-		"posts/diffing-post/attachments/legacy/moved.txt",
+		"posts/diffing-post/attachments/old-changed-sha.txt",
 	);
 	expect(s3.upload).toBeCalledWith(
 		"example-bucket",
-		"posts/diffing-post/attachments/moved.txt",
+		"posts/diffing-post/attachments/new-changed-sha.txt",
 		undefined,
 		expect.anything(),
 		"text/plain",
 	);
 
-	// Assert: unchanged attachment was NOT re-uploaded
+	// Assert: unchanged attachment was NOT re-uploaded or removed
 	expect(s3.upload).not.toBeCalledWith(
 		"example-bucket",
-		"posts/diffing-post/attachments/unchanged.txt",
+		"posts/diffing-post/attachments/unchanged-sha.txt",
 		undefined,
 		expect.anything(),
 		expect.anything(),
 	);
+	expect(s3.remove).not.toBeCalledWith(
+		"example-bucket",
+		"posts/diffing-post/attachments/unchanged-sha.txt",
+	);
 
-	// Assert: only the three attachments still present in the repo are saved
+	// Assert: only the two attachments still present in the repo are saved
 	expect(insertPostAttachmentsValues).toBeCalledWith([
 		{
 			postSlug: "diffing-post",
 			attachmentName: "unchanged.txt",
-			attachmentKey: "posts/diffing-post/attachments/unchanged.txt",
+			attachmentKey: "posts/diffing-post/attachments/unchanged-sha.txt",
+			sha: "unchanged-sha",
 			width: null,
 			height: null,
 		},
 		{
 			postSlug: "diffing-post",
 			attachmentName: "changed.txt",
-			attachmentKey: "posts/diffing-post/attachments/changed.txt",
+			attachmentKey: "posts/diffing-post/attachments/new-changed-sha.txt",
+			sha: "new-changed-sha",
 			width: null,
 			height: null,
 		},
+	]);
+});
+
+test("Skips an attachment entirely when its sha matches the stored value", async () => {
+	const insertPostsValues = vi.fn().mockReturnValue({
+		onConflictDoNothing: vi.fn(),
+	});
+	const insertPostDataValues = vi.fn().mockReturnValue({
+		onConflictDoUpdate: vi.fn(),
+	});
+	const insertPostAuthorsValues = vi.fn();
+	const insertPostAttachmentsValues = vi.fn();
+
+	vi.mocked(db.insert).mockImplementation((table) => {
+		if (table === posts) {
+			return { values: insertPostsValues } as never;
+		}
+		if (table === postData) {
+			return { values: insertPostDataValues } as never;
+		}
+		if (table === postAuthors) {
+			return { values: insertPostAuthorsValues } as never;
+		}
+		if (table === postAttachments) {
+			return { values: insertPostAttachmentsValues } as never;
+		}
+		throw new Error(`Unexpected table: ${table}`);
+	});
+
+	const deleteWhere = vi.fn();
+	vi.mocked(db.delete).mockReturnValue({
+		where: deleteWhere,
+	} as never);
+
+	vi.mocked(db.select).mockImplementation(
+		() =>
+			({
+				from: vi.fn((table: unknown) => ({
+					where: vi.fn().mockResolvedValue(
+						table === postAttachments
+							? [
+									{
+										attachmentName: "unchanged.txt",
+										attachmentKey:
+											"posts/skip-post/attachments/unchanged-sha.txt",
+										sha: "unchanged-sha",
+										width: null,
+										height: null,
+									},
+								]
+							: [],
+					),
+				})),
+			}) as never,
+	);
+
+	const basePath = "/content/example-author/posts/skip-post/";
+	const baseFolderPath = "content/example-author/posts/skip-post/";
+
+	vi.mocked(github.getContents).mockImplementation(((params: {
+		path: string;
+	}) => {
+		if (params.path === basePath) {
+			return Promise.resolve({
+				data: {
+					entries: [
+						{
+							name: "index.md",
+							path: `${baseFolderPath}index.md`,
+							type: "file",
+							sha: "index-sha",
+						},
+						{
+							name: "unchanged.txt",
+							path: `${baseFolderPath}unchanged.txt`,
+							type: "file",
+							sha: "unchanged-sha",
+						},
+					],
+				},
+				status: 200,
+			});
+		}
+		return Promise.reject(new Error(`Unexpected path: ${params.path}`));
+	}) as never);
+
+	vi.mocked(github.getContentsRaw).mockImplementation((params) => {
+		if (params.path === `/${baseFolderPath}index.md`) {
+			return Promise.resolve({
+				data: `---
+title: "Skip Post"
+published: "2024-01-15T00:00:00Z"
+---
+`,
+				status: 200,
+			});
+		}
+		return Promise.reject(new Error(`Unexpected path: ${params.path}`));
+	});
+
+	await processor({
+		data: {
+			author: "example-author",
+			post: "skip-post",
+			ref: "main",
+		},
+	} as unknown as Job<TaskInputs["sync-post"]>);
+
+	// Assert: the attachment's content was never fetched from GitHub, since its
+	// sha already matched the stored row
+	expect(github.getContentsRawStream).not.toBeCalledWith(
+		expect.objectContaining({ path: `/${baseFolderPath}unchanged.txt` }),
+	);
+
+	// Assert: no S3 interaction happened for the attachment itself (content.md
+	// is still uploaded separately as part of every sync)
+	expect(s3.upload).not.toBeCalledWith(
+		"example-bucket",
+		"posts/skip-post/attachments/unchanged-sha.txt",
+		expect.anything(),
+		expect.anything(),
+		expect.anything(),
+	);
+	expect(s3.remove).not.toBeCalled();
+
+	// Assert: the existing row was carried forward unchanged
+	expect(insertPostAttachmentsValues).toBeCalledWith([
 		{
-			postSlug: "diffing-post",
-			attachmentName: "moved.txt",
-			attachmentKey: "posts/diffing-post/attachments/moved.txt",
+			postSlug: "skip-post",
+			attachmentName: "unchanged.txt",
+			attachmentKey: "posts/skip-post/attachments/unchanged-sha.txt",
+			sha: "unchanged-sha",
 			width: null,
 			height: null,
 		},

--- a/apps/worker/src/tasks/sync-post/processor.ts
+++ b/apps/worker/src/tasks/sync-post/processor.ts
@@ -6,6 +6,7 @@ import {
 	postData,
 	postAuthors,
 	postTags,
+	postAttachments,
 } from "@playfulprogramming/db";
 import * as github from "@playfulprogramming/github-api";
 import { s3 } from "@playfulprogramming/s3";
@@ -13,9 +14,131 @@ import { createProcessor } from "../../createProcessor.ts";
 import { eq } from "drizzle-orm";
 import matter from "gray-matter";
 import { Value } from "typebox/value";
+import sharp from "sharp";
+import { Readable } from "node:stream";
+import { createHash } from "node:crypto";
+import { basename, dirname, extname } from "node:path/posix";
+import { Response } from "undici";
 import { PostMetaSchema } from "./types.ts";
 import { extractLocale } from "../../utils/extractLocale.ts";
 import { extractMarkdownExcerpt } from "../../utils/extractMarkdownExcerpt.ts";
+
+const ATTACHMENT_IMAGE_SIZE_MAX = 2048;
+
+const IMAGE_EXTENSIONS = new Set([
+	".jpg",
+	".jpeg",
+	".png",
+	".gif",
+	".webp",
+	".avif",
+	".bmp",
+	".tiff",
+]);
+
+const MIME_TYPES: Record<string, string> = {
+	".pdf": "application/pdf",
+	".ppt": "application/vnd.ms-powerpoint",
+	".pptx":
+		"application/vnd.openxmlformats-officedocument.presentationml.presentation",
+	".doc": "application/msword",
+	".docx":
+		"application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+	".xls": "application/vnd.ms-excel",
+	".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+	".zip": "application/zip",
+	".txt": "text/plain",
+	".csv": "text/csv",
+	".mp4": "video/mp4",
+	".webm": "video/webm",
+	".svg": "image/svg+xml",
+};
+
+function isImageAttachment(relativePath: string): boolean {
+	return IMAGE_EXTENSIONS.has(extname(relativePath).toLowerCase());
+}
+
+function mimeTypeForAttachment(relativePath: string): string {
+	return (
+		MIME_TYPES[extname(relativePath).toLowerCase()] ??
+		"application/octet-stream"
+	);
+}
+
+function withExtension(relativePath: string, newExt: string): string {
+	const dir = dirname(relativePath);
+	const base = basename(relativePath, extname(relativePath));
+	return dir === "." ? `${base}${newExt}` : `${dir}/${base}${newExt}`;
+}
+
+async function resizeAttachmentImage(stream: ReadableStream<Uint8Array>) {
+	const pipeline = sharp()
+		.resize({
+			width: ATTACHMENT_IMAGE_SIZE_MAX,
+			height: ATTACHMENT_IMAGE_SIZE_MAX,
+			fit: "inside",
+		})
+		.jpeg({ mozjpeg: true });
+
+	Readable.fromWeb(stream as never).pipe(pipeline);
+
+	const { data, info } = await pipeline.toBuffer({ resolveWithObject: true });
+
+	return { buffer: data, width: info.width, height: info.height };
+}
+
+interface AttachmentSourceEntry {
+	relativePath: string;
+	path: string;
+}
+
+async function collectAttachmentEntries(
+	entries: Array<{ name: string; path: string; type?: string }>,
+	baseFolderPath: string,
+	ref: string,
+	signal: AbortSignal | undefined,
+): Promise<AttachmentSourceEntry[]> {
+	const results: AttachmentSourceEntry[] = [];
+
+	for (const entry of entries) {
+		if (entry.name.startsWith("index") && entry.name.endsWith(".md")) {
+			continue;
+		}
+
+		if (entry.type === "dir") {
+			const dirPath = new URL(`${entry.path}/`, "http://localhost").pathname;
+			const dirResponse = await github.getContents({
+				ref,
+				path: dirPath,
+				repoOwner: env.GITHUB_REPO_OWNER,
+				repoName: env.GITHUB_REPO_NAME,
+				signal,
+			});
+
+			if (
+				dirResponse.data !== undefined &&
+				Array.isArray(dirResponse.data.entries)
+			) {
+				results.push(
+					...(await collectAttachmentEntries(
+						dirResponse.data.entries,
+						baseFolderPath,
+						ref,
+						signal,
+					)),
+				);
+			}
+			continue;
+		}
+
+		results.push({
+			relativePath: entry.path.slice(baseFolderPath.length),
+			path: entry.path,
+		});
+	}
+
+	return results;
+}
 
 export default createProcessor(Tasks.SYNC_POST, async (job, { signal }) => {
 	const { author, post, collection, ref } = job.data;
@@ -45,6 +168,19 @@ export default createProcessor(Tasks.SYNC_POST, async (job, { signal }) => {
 			console.log(
 				`Post ${post} (${basePath}) returned 404 - removing from database.`,
 			);
+
+			const removedAttachmentRows = await db
+				.select({ attachmentKey: postAttachments.attachmentKey })
+				.from(postAttachments)
+				.where(eq(postAttachments.postSlug, post));
+
+			if (removedAttachmentRows.length > 0) {
+				const bucket = await s3.ensureBucket(env.S3_BUCKET);
+				for (const { attachmentKey } of removedAttachmentRows) {
+					await s3.remove(bucket, attachmentKey);
+					console.log(`Removed attachment ${attachmentKey} from S3`);
+				}
+			}
 
 			const removedAuthorRows = await db
 				.select({ authorSlug: postAuthors.authorSlug })
@@ -154,7 +290,107 @@ export default createProcessor(Tasks.SYNC_POST, async (job, { signal }) => {
 	);
 
 	// =========================================================================
-	// Phase 3: Perform all database operations in a single transaction
+	// Phase 3: Discover, resize, diff, and upload post attachments
+	// =========================================================================
+	const baseFolderPath = basePath.replace(/^\//, "");
+	const attachmentEntries = await collectAttachmentEntries(
+		folderResponse.data.entries,
+		baseFolderPath,
+		ref,
+		signal,
+	);
+
+	const previousAttachmentRows = await db
+		.select({
+			attachmentName: postAttachments.attachmentName,
+			attachmentKey: postAttachments.attachmentKey,
+		})
+		.from(postAttachments)
+		.where(eq(postAttachments.postSlug, post));
+	const previousAttachmentsByName = new Map(
+		previousAttachmentRows.map((row) => [row.attachmentName, row]),
+	);
+
+	const discoveredAttachmentNames = new Set(
+		attachmentEntries.map((entry) => entry.relativePath),
+	);
+
+	for (const [attachmentName, row] of previousAttachmentsByName) {
+		if (!discoveredAttachmentNames.has(attachmentName)) {
+			await s3.remove(bucket, row.attachmentKey);
+			console.log(
+				`Removed attachment ${row.attachmentKey} from S3 (no longer in repo)`,
+			);
+		}
+	}
+
+	const attachmentRows = await Promise.all(
+		attachmentEntries.map(async ({ relativePath, path }) => {
+			const fileUrl = new URL(path, "http://localhost");
+			const { data: fileStream } = await github.getContentsRawStream({
+				ref,
+				path: fileUrl.pathname,
+				repoOwner: env.GITHUB_REPO_OWNER,
+				repoName: env.GITHUB_REPO_NAME,
+				signal,
+			});
+
+			if (fileStream === undefined) {
+				throw new Error(
+					`Unable to fetch attachment ${relativePath} for ${post}`,
+				);
+			}
+
+			const isImage = isImageAttachment(relativePath);
+			let buffer: Buffer;
+			let width: number | null = null;
+			let height: number | null = null;
+			let keyRelativePath = relativePath;
+
+			if (isImage) {
+				const resized = await resizeAttachmentImage(fileStream);
+				buffer = resized.buffer;
+				width = resized.width;
+				height = resized.height;
+				keyRelativePath = withExtension(relativePath, ".jpeg");
+			} else {
+				buffer = Buffer.from(await new Response(fileStream).arrayBuffer());
+			}
+
+			const attachmentKey = `posts/${post}/attachments/${keyRelativePath}`;
+			const etag = `"${createHash("md5").update(buffer).digest("hex")}"`;
+
+			const previous = previousAttachmentsByName.get(relativePath);
+			const unchanged =
+				previous?.attachmentKey === attachmentKey &&
+				(await s3.matchesEtag(bucket, attachmentKey, etag));
+
+			if (!unchanged) {
+				if (previous && (await s3.exists(bucket, previous.attachmentKey))) {
+					await s3.remove(bucket, previous.attachmentKey);
+				}
+				await s3.upload(
+					bucket,
+					attachmentKey,
+					undefined,
+					buffer,
+					isImage ? "image/jpeg" : mimeTypeForAttachment(relativePath),
+				);
+				console.log(`Uploaded attachment ${attachmentKey} to S3`);
+			}
+
+			return {
+				postSlug: post,
+				attachmentName: relativePath,
+				attachmentKey,
+				width,
+				height,
+			};
+		}),
+	);
+
+	// =========================================================================
+	// Phase 4: Perform all database operations in a single transaction
 	// =========================================================================
 	const previousAuthorRows = await db
 		.select({ authorSlug: postAuthors.authorSlug })
@@ -222,6 +458,12 @@ export default createProcessor(Tasks.SYNC_POST, async (job, { signal }) => {
 					tag,
 				})),
 			);
+		}
+
+		await tx.delete(postAttachments).where(eq(postAttachments.postSlug, post));
+
+		if (attachmentRows.length > 0) {
+			await tx.insert(postAttachments).values(attachmentRows);
 		}
 	});
 

--- a/apps/worker/src/tasks/sync-post/processor.ts
+++ b/apps/worker/src/tasks/sync-post/processor.ts
@@ -16,7 +16,6 @@ import matter from "gray-matter";
 import { Value } from "typebox/value";
 import sharp from "sharp";
 import { Readable } from "node:stream";
-import { createHash } from "node:crypto";
 import { extname } from "node:path/posix";
 import { Response } from "undici";
 import { PostMetaSchema } from "./types.ts";
@@ -52,6 +51,7 @@ const MIME_TYPES: Record<string, string> = {
 	".mp4": "video/mp4",
 	".webm": "video/webm",
 	".svg": "image/svg+xml",
+	".jpeg": "image/jpeg",
 };
 
 function isImageAttachment(relativePath: string): boolean {
@@ -83,73 +83,30 @@ async function resizeAttachmentImage(stream: ReadableStream<Uint8Array>) {
 }
 
 interface AttachmentSourceEntry {
-	relativePath: string;
+	name: string;
 	path: string;
+	sha: string;
 }
 
-async function collectAttachmentEntries(
-	entries: Array<{ name: string; path: string; type?: string }>,
-	baseFolderPath: string,
-	ref: string,
-	signal: AbortSignal | undefined,
-): Promise<AttachmentSourceEntry[]> {
-	const results: AttachmentSourceEntry[] = [];
-
-	for (const entry of entries) {
-		if (entry.name.startsWith("index") && entry.name.endsWith(".md")) {
-			continue;
-		}
-
-		if (entry.type === "dir") {
-			const dirPath = new URL(`${entry.path}/`, "http://localhost").pathname;
-			const dirResponse = await github.getContents({
-				ref,
-				path: dirPath,
-				repoOwner: env.GITHUB_REPO_OWNER,
-				repoName: env.GITHUB_REPO_NAME,
-				signal,
-			});
-
-			if (
-				dirResponse.data !== undefined &&
-				Array.isArray(dirResponse.data.entries)
-			) {
-				results.push(
-					...(await collectAttachmentEntries(
-						dirResponse.data.entries,
-						baseFolderPath,
-						ref,
-						signal,
-					)),
-				);
-			}
-			continue;
-		}
-
-		results.push({
-			relativePath: entry.path.slice(baseFolderPath.length),
-			path: entry.path,
-		});
-	}
-
-	return results;
+function collectAttachmentEntries(
+	entries: Array<{ name: string; path: string; type?: string; sha: string }>,
+): AttachmentSourceEntry[] {
+	return entries
+		.filter((entry) => entry.type !== "dir")
+		.filter(
+			(entry) =>
+				!(entry.name.startsWith("index") && entry.name.endsWith(".md")),
+		)
+		.map((entry) => ({ name: entry.name, path: entry.path, sha: entry.sha }));
 }
 
-const ATTACHMENT_UPLOAD_CONCURRENCY = 4;
-
-async function processInBatches<T, R>(
-	items: T[],
-	concurrency: number,
-	fn: (item: T) => Promise<R>,
-): Promise<R[]> {
-	const results: R[] = [];
-
-	for (let i = 0; i < items.length; i += concurrency) {
-		const chunk = items.slice(i, i + concurrency);
-		results.push(...(await Promise.all(chunk.map(fn))));
-	}
-
-	return results;
+interface AttachmentRow {
+	postSlug: string;
+	attachmentName: string;
+	attachmentKey: string;
+	sha: string;
+	width: number | null;
+	height: number | null;
 }
 
 export default createProcessor(Tasks.SYNC_POST, async (job, { signal }) => {
@@ -188,21 +145,12 @@ export default createProcessor(Tasks.SYNC_POST, async (job, { signal }) => {
 
 			if (removedAttachmentRows.length > 0) {
 				const bucket = await s3.ensureBucket(env.S3_BUCKET);
-				const results = await Promise.allSettled(
+				await Promise.all(
 					removedAttachmentRows.map(async ({ attachmentKey }) => {
 						await s3.remove(bucket, attachmentKey);
 						console.log(`Removed attachment ${attachmentKey} from S3`);
 					}),
 				);
-
-				for (const result of results) {
-					if (result.status === "rejected") {
-						console.error(
-							result.reason,
-							`Failed to remove an attachment from S3 for ${post}`,
-						);
-					}
-				}
 			}
 
 			const removedAuthorRows = await db
@@ -315,18 +263,17 @@ export default createProcessor(Tasks.SYNC_POST, async (job, { signal }) => {
 	// =========================================================================
 	// Phase 3: Discover, resize, diff, and upload post attachments
 	// =========================================================================
-	const baseFolderPath = basePath.replace(/^\//, "");
-	const attachmentEntries = await collectAttachmentEntries(
+	const attachmentEntries = collectAttachmentEntries(
 		folderResponse.data.entries,
-		baseFolderPath,
-		ref,
-		signal,
 	);
 
 	const previousAttachmentRows = await db
 		.select({
 			attachmentName: postAttachments.attachmentName,
 			attachmentKey: postAttachments.attachmentKey,
+			sha: postAttachments.sha,
+			width: postAttachments.width,
+			height: postAttachments.height,
 		})
 		.from(postAttachments)
 		.where(eq(postAttachments.postSlug, post));
@@ -335,7 +282,7 @@ export default createProcessor(Tasks.SYNC_POST, async (job, { signal }) => {
 	);
 
 	const discoveredAttachmentNames = new Set(
-		attachmentEntries.map((entry) => entry.relativePath),
+		attachmentEntries.map((entry) => entry.name),
 	);
 
 	for (const [attachmentName, row] of previousAttachmentsByName) {
@@ -347,87 +294,81 @@ export default createProcessor(Tasks.SYNC_POST, async (job, { signal }) => {
 		}
 	}
 
-	const attachmentRows = await processInBatches(
-		attachmentEntries,
-		ATTACHMENT_UPLOAD_CONCURRENCY,
-		async ({ relativePath, path }) => {
-			const fileUrl = new URL(path, "http://localhost");
-			const { data: fileStream } = await github.getContentsRawStream({
-				ref,
-				path: fileUrl.pathname,
-				repoOwner: env.GITHUB_REPO_OWNER,
-				repoName: env.GITHUB_REPO_NAME,
-				signal,
-			});
+	const attachmentRows: AttachmentRow[] = [];
 
-			if (fileStream === undefined) {
-				throw new Error(
-					`Unable to fetch attachment ${relativePath} for ${post}`,
-				);
-			}
+	for (const { name, path, sha } of attachmentEntries) {
+		const previous = previousAttachmentsByName.get(name);
 
-			const isImage = isImageAttachment(relativePath);
-			let buffer: Buffer;
-			let width: number | null = null;
-			let height: number | null = null;
-			// Images are converted to JPEG, so ".jpeg" is appended after the full
-			// original filename (rather than replacing its extension) to keep the
-			// key's extension honest about the stored format without colliding on
-			// same-basename files with different source extensions (e.g. banner.png
-			// and banner.jpg would otherwise both become banner.jpeg).
-			let keyRelativePath = relativePath;
-
-			if (isImage) {
-				const resized = await resizeAttachmentImage(fileStream);
-				buffer = resized.buffer;
-				width = resized.width;
-				height = resized.height;
-				keyRelativePath = `${relativePath}.jpeg`;
-			} else {
-				buffer = Buffer.from(await new Response(fileStream).arrayBuffer());
-			}
-
-			const attachmentKey = `posts/${post}/attachments/${keyRelativePath}`;
-			const etag = `"${createHash("md5").update(buffer).digest("hex")}"`;
-
-			const previous = previousAttachmentsByName.get(relativePath);
-			const sameKeyAsPrevious =
-				previous !== undefined && previous.attachmentKey === attachmentKey;
-			const unchanged =
-				sameKeyAsPrevious &&
-				(await s3.matchesEtag(bucket, attachmentKey, etag));
-
-			if (!unchanged) {
-				if (
-					previous !== undefined &&
-					!sameKeyAsPrevious &&
-					(await s3.exists(bucket, previous.attachmentKey))
-				) {
-					// Only pre-emptively delete when the key itself changed; when the
-					// key is unchanged, s3.upload below overwrites it directly, so
-					// deleting first would just create a needless gap where the
-					// object briefly doesn't exist.
-					await s3.remove(bucket, previous.attachmentKey);
-				}
-				await s3.upload(
-					bucket,
-					attachmentKey,
-					undefined,
-					buffer,
-					isImage ? "image/jpeg" : mimeTypeForAttachment(relativePath),
-				);
-				console.log(`Uploaded attachment ${attachmentKey} to S3`);
-			}
-
-			return {
+		// Content-addressed keys mean an unchanged sha implies an unchanged
+		// object in S3 - carry the existing row forward without touching GitHub
+		// or S3 at all.
+		if (previous !== undefined && previous.sha === sha) {
+			attachmentRows.push({
 				postSlug: post,
-				attachmentName: relativePath,
-				attachmentKey,
-				width,
-				height,
-			};
-		},
-	);
+				attachmentName: name,
+				attachmentKey: previous.attachmentKey,
+				sha,
+				width: previous.width,
+				height: previous.height,
+			});
+			continue;
+		}
+
+		const fileUrl = new URL(path, "http://localhost");
+		const { data: fileStream } = await github.getContentsRawStream({
+			ref,
+			path: fileUrl.pathname,
+			repoOwner: env.GITHUB_REPO_OWNER,
+			repoName: env.GITHUB_REPO_NAME,
+			signal,
+		});
+
+		if (fileStream === undefined) {
+			throw new Error(`Unable to fetch attachment ${name} for ${post}`);
+		}
+
+		const isImage = isImageAttachment(name);
+		let buffer: Buffer;
+		let width: number | null = null;
+		let height: number | null = null;
+
+		if (isImage) {
+			const resized = await resizeAttachmentImage(fileStream);
+			buffer = resized.buffer;
+			width = resized.width;
+			height = resized.height;
+		} else {
+			buffer = Buffer.from(await new Response(fileStream).arrayBuffer());
+		}
+
+		// The key is derived from the file's sha, so a changed file always gets
+		// a brand-new key - no risk of collision, and no need to reason about
+		// whether the key itself changed before deleting the old object.
+		const extension = isImage ? ".jpeg" : extname(name);
+		const attachmentKey = `posts/${post}/attachments/${sha}${extension}`;
+
+		if (previous !== undefined) {
+			await s3.remove(bucket, previous.attachmentKey);
+		}
+
+		await s3.upload(
+			bucket,
+			attachmentKey,
+			undefined,
+			buffer,
+			mimeTypeForAttachment(attachmentKey),
+		);
+		console.log(`Uploaded attachment ${attachmentKey} to S3`);
+
+		attachmentRows.push({
+			postSlug: post,
+			attachmentName: name,
+			attachmentKey,
+			sha,
+			width,
+			height,
+		});
+	}
 
 	// =========================================================================
 	// Phase 4: Perform all database operations in a single transaction

--- a/apps/worker/src/tasks/sync-post/processor.ts
+++ b/apps/worker/src/tasks/sync-post/processor.ts
@@ -314,10 +314,9 @@ export default createProcessor(Tasks.SYNC_POST, async (job, { signal }) => {
 			continue;
 		}
 
-		const fileUrl = new URL(path, "http://localhost");
 		const { data: fileStream } = await github.getContentsRawStream({
 			ref,
-			path: fileUrl.pathname,
+			path,
 			repoOwner: env.GITHUB_REPO_OWNER,
 			repoName: env.GITHUB_REPO_NAME,
 			signal,
@@ -342,14 +341,11 @@ export default createProcessor(Tasks.SYNC_POST, async (job, { signal }) => {
 		}
 
 		// The key is derived from the file's sha, so a changed file always gets
-		// a brand-new key - no risk of collision, and no need to reason about
-		// whether the key itself changed before deleting the old object.
+		// a brand-new key - no risk of collision. Upload the new object before
+		// removing the old one, so a failed upload doesn't leave the persisted
+		// row pointing at a key that no longer exists in S3.
 		const extension = isImage ? ".jpeg" : extname(name);
 		const attachmentKey = `posts/${post}/attachments/${sha}${extension}`;
-
-		if (previous !== undefined) {
-			await s3.remove(bucket, previous.attachmentKey);
-		}
 
 		await s3.upload(
 			bucket,
@@ -359,6 +355,10 @@ export default createProcessor(Tasks.SYNC_POST, async (job, { signal }) => {
 			mimeTypeForAttachment(attachmentKey),
 		);
 		console.log(`Uploaded attachment ${attachmentKey} to S3`);
+
+		if (previous !== undefined) {
+			await s3.remove(bucket, previous.attachmentKey);
+		}
 
 		attachmentRows.push({
 			postSlug: post,

--- a/apps/worker/src/tasks/sync-post/processor.ts
+++ b/apps/worker/src/tasks/sync-post/processor.ts
@@ -17,7 +17,7 @@ import { Value } from "typebox/value";
 import sharp from "sharp";
 import { Readable } from "node:stream";
 import { createHash } from "node:crypto";
-import { basename, dirname, extname } from "node:path/posix";
+import { extname } from "node:path/posix";
 import { Response } from "undici";
 import { PostMetaSchema } from "./types.ts";
 import { extractLocale } from "../../utils/extractLocale.ts";
@@ -65,18 +65,13 @@ function mimeTypeForAttachment(relativePath: string): string {
 	);
 }
 
-function withExtension(relativePath: string, newExt: string): string {
-	const dir = dirname(relativePath);
-	const base = basename(relativePath, extname(relativePath));
-	return dir === "." ? `${base}${newExt}` : `${dir}/${base}${newExt}`;
-}
-
 async function resizeAttachmentImage(stream: ReadableStream<Uint8Array>) {
 	const pipeline = sharp()
 		.resize({
 			width: ATTACHMENT_IMAGE_SIZE_MAX,
 			height: ATTACHMENT_IMAGE_SIZE_MAX,
 			fit: "inside",
+			withoutEnlargement: true,
 		})
 		.jpeg({ mozjpeg: true });
 
@@ -140,6 +135,23 @@ async function collectAttachmentEntries(
 	return results;
 }
 
+const ATTACHMENT_UPLOAD_CONCURRENCY = 4;
+
+async function processInBatches<T, R>(
+	items: T[],
+	concurrency: number,
+	fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+	const results: R[] = [];
+
+	for (let i = 0; i < items.length; i += concurrency) {
+		const chunk = items.slice(i, i + concurrency);
+		results.push(...(await Promise.all(chunk.map(fn))));
+	}
+
+	return results;
+}
+
 export default createProcessor(Tasks.SYNC_POST, async (job, { signal }) => {
 	const { author, post, collection, ref } = job.data;
 
@@ -176,9 +188,20 @@ export default createProcessor(Tasks.SYNC_POST, async (job, { signal }) => {
 
 			if (removedAttachmentRows.length > 0) {
 				const bucket = await s3.ensureBucket(env.S3_BUCKET);
-				for (const { attachmentKey } of removedAttachmentRows) {
-					await s3.remove(bucket, attachmentKey);
-					console.log(`Removed attachment ${attachmentKey} from S3`);
+				const results = await Promise.allSettled(
+					removedAttachmentRows.map(async ({ attachmentKey }) => {
+						await s3.remove(bucket, attachmentKey);
+						console.log(`Removed attachment ${attachmentKey} from S3`);
+					}),
+				);
+
+				for (const result of results) {
+					if (result.status === "rejected") {
+						console.error(
+							result.reason,
+							`Failed to remove an attachment from S3 for ${post}`,
+						);
+					}
 				}
 			}
 
@@ -324,8 +347,10 @@ export default createProcessor(Tasks.SYNC_POST, async (job, { signal }) => {
 		}
 	}
 
-	const attachmentRows = await Promise.all(
-		attachmentEntries.map(async ({ relativePath, path }) => {
+	const attachmentRows = await processInBatches(
+		attachmentEntries,
+		ATTACHMENT_UPLOAD_CONCURRENCY,
+		async ({ relativePath, path }) => {
 			const fileUrl = new URL(path, "http://localhost");
 			const { data: fileStream } = await github.getContentsRawStream({
 				ref,
@@ -345,6 +370,11 @@ export default createProcessor(Tasks.SYNC_POST, async (job, { signal }) => {
 			let buffer: Buffer;
 			let width: number | null = null;
 			let height: number | null = null;
+			// Images are converted to JPEG, so ".jpeg" is appended after the full
+			// original filename (rather than replacing its extension) to keep the
+			// key's extension honest about the stored format without colliding on
+			// same-basename files with different source extensions (e.g. banner.png
+			// and banner.jpg would otherwise both become banner.jpeg).
 			let keyRelativePath = relativePath;
 
 			if (isImage) {
@@ -352,7 +382,7 @@ export default createProcessor(Tasks.SYNC_POST, async (job, { signal }) => {
 				buffer = resized.buffer;
 				width = resized.width;
 				height = resized.height;
-				keyRelativePath = withExtension(relativePath, ".jpeg");
+				keyRelativePath = `${relativePath}.jpeg`;
 			} else {
 				buffer = Buffer.from(await new Response(fileStream).arrayBuffer());
 			}
@@ -361,12 +391,22 @@ export default createProcessor(Tasks.SYNC_POST, async (job, { signal }) => {
 			const etag = `"${createHash("md5").update(buffer).digest("hex")}"`;
 
 			const previous = previousAttachmentsByName.get(relativePath);
+			const sameKeyAsPrevious =
+				previous !== undefined && previous.attachmentKey === attachmentKey;
 			const unchanged =
-				previous?.attachmentKey === attachmentKey &&
+				sameKeyAsPrevious &&
 				(await s3.matchesEtag(bucket, attachmentKey, etag));
 
 			if (!unchanged) {
-				if (previous && (await s3.exists(bucket, previous.attachmentKey))) {
+				if (
+					previous !== undefined &&
+					!sameKeyAsPrevious &&
+					(await s3.exists(bucket, previous.attachmentKey))
+				) {
+					// Only pre-emptively delete when the key itself changed; when the
+					// key is unchanged, s3.upload below overwrites it directly, so
+					// deleting first would just create a needless gap where the
+					// object briefly doesn't exist.
 					await s3.remove(bucket, previous.attachmentKey);
 				}
 				await s3.upload(
@@ -386,7 +426,7 @@ export default createProcessor(Tasks.SYNC_POST, async (job, { signal }) => {
 				width,
 				height,
 			};
-		}),
+		},
 	);
 
 	// =========================================================================

--- a/apps/worker/test-utils/setup.ts
+++ b/apps/worker/test-utils/setup.ts
@@ -23,8 +23,6 @@ vi.mock("@playfulprogramming/s3", () => {
 			ensureBucket: vi.fn(() => "example-bucket"),
 			upload: vi.fn(),
 			remove: vi.fn(),
-			exists: vi.fn(() => false),
-			matchesEtag: vi.fn(() => false),
 		},
 	};
 });

--- a/apps/worker/test-utils/setup.ts
+++ b/apps/worker/test-utils/setup.ts
@@ -23,6 +23,8 @@ vi.mock("@playfulprogramming/s3", () => {
 			ensureBucket: vi.fn(() => "example-bucket"),
 			upload: vi.fn(),
 			remove: vi.fn(),
+			exists: vi.fn(() => false),
+			matchesEtag: vi.fn(() => false),
 		},
 	};
 });
@@ -93,6 +95,10 @@ vi.mock("@playfulprogramming/db", () => {
 		postTags: {
 			postSlug: {},
 			tag: {},
+		},
+		postAttachments: {
+			postSlug: {},
+			attachmentName: {},
 		},
 		collectionChapters: {
 			postSlug: {},

--- a/packages/db/drizzle/20260705145304_curious_zuras/migration.sql
+++ b/packages/db/drizzle/20260705145304_curious_zuras/migration.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "post_attachments" (
+	"post_slug" text,
+	"attachment_name" text,
+	"attachment_key" text NOT NULL,
+	"width" integer,
+	"height" integer,
+	CONSTRAINT "post_attachments_pkey" PRIMARY KEY("post_slug","attachment_name")
+);
+--> statement-breakpoint
+ALTER TABLE "post_attachments" ADD CONSTRAINT "post_attachments_post_slug_posts_slug_fkey" FOREIGN KEY ("post_slug") REFERENCES "posts"("slug") ON DELETE CASCADE;

--- a/packages/db/drizzle/20260705145304_curious_zuras/snapshot.json
+++ b/packages/db/drizzle/20260705145304_curious_zuras/snapshot.json
@@ -1,0 +1,1712 @@
+{
+  "version": "8",
+  "dialect": "postgres",
+  "id": "529d4cba-f0e6-4ca9-bb8e-e74de1eb3425",
+  "prevIds": [
+    "a9cd32a6-e23f-4121-bc8f-6d4282e95a3c",
+    "e66fa34b-90bc-4916-a2b3-3c783ad69266"
+  ],
+  "ddl": [
+    {
+      "isRlsEnabled": false,
+      "name": "profile_achievements",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "profiles",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "collection_authors",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "collection_data",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "collections",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "post_authors",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "post_data",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "posts",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "post_images",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "url_metadata",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "url_metadata_gist",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "url_metadata_gist_file",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "url_metadata_post",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "collection_tags",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "post_tags",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "post_attachments",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "profile_slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_achievements"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "achievement_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_achievements"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "granted_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_achievements"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "''",
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "profile_image",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profiles"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "published_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profiles"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "meta",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "collection_slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_authors"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "author_slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_authors"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "locale",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "''",
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "published_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "meta",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "cover_image",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "social_image",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collections"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "post_slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_authors"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "author_slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_authors"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "locale",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "''",
+      "generated": null,
+      "identity": null,
+      "name": "version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "''",
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "word_count",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "social_image",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "banner_image",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "original_link",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "noindex",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "edited_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "published_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "meta",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "collection_slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "collection_order",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_images"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "banner_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_images"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "link_preview_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_images"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "index_md5",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_images"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "fetched_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_images"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "error",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_images"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "url",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "icon_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "icon_width",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "icon_height",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "banner_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "banner_width",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "banner_height",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "gist_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "post_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "embed_src",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "embed_width",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "embed_height",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "embed_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "fetched_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "error",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "gist_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_gist"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "username",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_gist"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_gist"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "gist_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_gist_file"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "filename",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_gist_file"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "content_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_gist_file"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "language",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_gist_file"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "post_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "author_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "author_handle",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "content",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "url",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "avatar_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "avatar_width",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "avatar_height",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image_width",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image_height",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image_alt_text",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "num_likes",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "num_reposts",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "num_replies",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "collection_slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_tags"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "tag",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_tags"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "post_slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_tags"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "tag",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_tags"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "post_slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_attachments"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "attachment_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_attachments"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "attachment_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_attachments"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "width",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_attachments"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "height",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_attachments"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "profile_slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "profiles",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "profile_achievements_profile_slug_profiles_slug_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "profile_achievements"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "collection_slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "collections",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "collection_authors_collection_slug_collections_slug_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "collection_authors"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "author_slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "profiles",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "collection_authors_author_slug_profiles_slug_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "collection_authors"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "collections",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "collection_data_slug_collections_slug_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "post_slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "posts",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "post_authors_post_slug_posts_slug_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "post_authors"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "author_slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "profiles",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "post_authors_author_slug_profiles_slug_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "post_authors"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "posts",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "post_data_slug_posts_slug_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "collection_slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "collections",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "name": "posts_collection_slug_collections_slug_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "gist_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "url_metadata_gist",
+      "columnsTo": [
+        "gist_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "name": "url_metadata_gist_id_url_metadata_gist_gist_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "post_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "url_metadata_post",
+      "columnsTo": [
+        "post_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "name": "url_metadata_post_id_url_metadata_post_post_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "gist_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "url_metadata_gist",
+      "columnsTo": [
+        "gist_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "url_metadata_gist_file_gist_id_url_metadata_gist_gist_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "url_metadata_gist_file"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "collection_slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "collections",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "collection_tags_collection_slug_collections_slug_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "collection_tags"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "post_slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "posts",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "post_tags_post_slug_posts_slug_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "post_tags"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "post_slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "posts",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "post_attachments_post_slug_posts_slug_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "post_attachments"
+    },
+    {
+      "columns": [
+        "profile_slug",
+        "achievement_id"
+      ],
+      "nameExplicit": false,
+      "name": "profile_achievements_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "profile_achievements"
+    },
+    {
+      "columns": [
+        "collection_slug",
+        "author_slug"
+      ],
+      "nameExplicit": false,
+      "name": "collection_authors_collection_slug_author_slug_pk",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "collection_authors"
+    },
+    {
+      "columns": [
+        "slug",
+        "locale"
+      ],
+      "nameExplicit": false,
+      "name": "collection_data_slug_locale_pk",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "columns": [
+        "post_slug",
+        "author_slug"
+      ],
+      "nameExplicit": false,
+      "name": "post_authors_post_slug_author_slug_pk",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "post_authors"
+    },
+    {
+      "columns": [
+        "slug",
+        "locale",
+        "version"
+      ],
+      "nameExplicit": false,
+      "name": "post_data_slug_locale_version_pk",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "columns": [
+        "gist_id",
+        "filename"
+      ],
+      "nameExplicit": false,
+      "name": "url_metadata_gist_file_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "url_metadata_gist_file"
+    },
+    {
+      "columns": [
+        "collection_slug",
+        "tag"
+      ],
+      "nameExplicit": false,
+      "name": "collection_tags_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "collection_tags"
+    },
+    {
+      "columns": [
+        "post_slug",
+        "tag"
+      ],
+      "nameExplicit": false,
+      "name": "post_tags_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "post_tags"
+    },
+    {
+      "columns": [
+        "post_slug",
+        "attachment_name"
+      ],
+      "nameExplicit": false,
+      "name": "post_attachments_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "post_attachments"
+    },
+    {
+      "columns": [
+        "slug"
+      ],
+      "nameExplicit": false,
+      "name": "profiles_pkey",
+      "schema": "public",
+      "table": "profiles",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "slug"
+      ],
+      "nameExplicit": false,
+      "name": "collections_pkey",
+      "schema": "public",
+      "table": "collections",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "slug"
+      ],
+      "nameExplicit": false,
+      "name": "posts_pkey",
+      "schema": "public",
+      "table": "posts",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "slug"
+      ],
+      "nameExplicit": false,
+      "name": "post_images_pkey",
+      "schema": "public",
+      "table": "post_images",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "url"
+      ],
+      "nameExplicit": false,
+      "name": "url_metadata_pkey",
+      "schema": "public",
+      "table": "url_metadata",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "gist_id"
+      ],
+      "nameExplicit": false,
+      "name": "url_metadata_gist_pkey",
+      "schema": "public",
+      "table": "url_metadata_gist",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "post_id"
+      ],
+      "nameExplicit": false,
+      "name": "url_metadata_post_pkey",
+      "schema": "public",
+      "table": "url_metadata_post",
+      "entityType": "pks"
+    }
+  ],
+  "renames": []
+}

--- a/packages/db/drizzle/20260710142207_violet_revanche/migration.sql
+++ b/packages/db/drizzle/20260710142207_violet_revanche/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "post_attachments" ADD COLUMN "sha" text NOT NULL;

--- a/packages/db/drizzle/20260710142207_violet_revanche/snapshot.json
+++ b/packages/db/drizzle/20260710142207_violet_revanche/snapshot.json
@@ -1,0 +1,1724 @@
+{
+  "version": "8",
+  "dialect": "postgres",
+  "id": "21b57418-aed2-421c-96ea-46a68958ce8d",
+  "prevIds": [
+    "529d4cba-f0e6-4ca9-bb8e-e74de1eb3425"
+  ],
+  "ddl": [
+    {
+      "isRlsEnabled": false,
+      "name": "profile_achievements",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "profiles",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "collection_authors",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "collection_data",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "collections",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "post_authors",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "post_data",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "posts",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "post_images",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "url_metadata",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "url_metadata_gist",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "url_metadata_gist_file",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "url_metadata_post",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "collection_tags",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "post_tags",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "post_attachments",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "profile_slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_achievements"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "achievement_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_achievements"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "granted_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_achievements"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "''",
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "profile_image",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profiles"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "published_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profiles"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "meta",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "collection_slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_authors"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "author_slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_authors"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "locale",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "''",
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "published_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "meta",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "cover_image",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "social_image",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collections"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "post_slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_authors"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "author_slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_authors"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "locale",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "''",
+      "generated": null,
+      "identity": null,
+      "name": "version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "''",
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "word_count",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "social_image",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "banner_image",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "original_link",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "noindex",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "edited_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "published_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "meta",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "collection_slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "collection_order",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_images"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "banner_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_images"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "link_preview_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_images"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "index_md5",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_images"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "fetched_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_images"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "error",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_images"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "url",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "icon_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "icon_width",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "icon_height",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "banner_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "banner_width",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "banner_height",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "gist_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "post_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "embed_src",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "embed_width",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "embed_height",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "embed_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "fetched_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "error",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "gist_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_gist"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "username",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_gist"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_gist"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "gist_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_gist_file"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "filename",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_gist_file"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "content_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_gist_file"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "language",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_gist_file"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "post_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "author_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "author_handle",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "content",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "url",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "avatar_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "avatar_width",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "avatar_height",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image_width",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image_height",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image_alt_text",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "num_likes",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "num_reposts",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "num_replies",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "collection_slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_tags"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "tag",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_tags"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "post_slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_tags"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "tag",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_tags"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "post_slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_attachments"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "attachment_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_attachments"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "attachment_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_attachments"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "sha",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_attachments"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "width",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_attachments"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "height",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_attachments"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "profile_slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "profiles",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "profile_achievements_profile_slug_profiles_slug_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "profile_achievements"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "collection_slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "collections",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "collection_authors_collection_slug_collections_slug_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "collection_authors"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "author_slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "profiles",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "collection_authors_author_slug_profiles_slug_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "collection_authors"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "collections",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "collection_data_slug_collections_slug_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "post_slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "posts",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "post_authors_post_slug_posts_slug_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "post_authors"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "author_slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "profiles",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "post_authors_author_slug_profiles_slug_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "post_authors"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "posts",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "post_data_slug_posts_slug_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "collection_slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "collections",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "name": "posts_collection_slug_collections_slug_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "gist_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "url_metadata_gist",
+      "columnsTo": [
+        "gist_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "name": "url_metadata_gist_id_url_metadata_gist_gist_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "post_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "url_metadata_post",
+      "columnsTo": [
+        "post_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "name": "url_metadata_post_id_url_metadata_post_post_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "gist_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "url_metadata_gist",
+      "columnsTo": [
+        "gist_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "url_metadata_gist_file_gist_id_url_metadata_gist_gist_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "url_metadata_gist_file"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "collection_slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "collections",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "collection_tags_collection_slug_collections_slug_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "collection_tags"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "post_slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "posts",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "post_tags_post_slug_posts_slug_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "post_tags"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "post_slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "posts",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "post_attachments_post_slug_posts_slug_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "post_attachments"
+    },
+    {
+      "columns": [
+        "profile_slug",
+        "achievement_id"
+      ],
+      "nameExplicit": false,
+      "name": "profile_achievements_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "profile_achievements"
+    },
+    {
+      "columns": [
+        "collection_slug",
+        "author_slug"
+      ],
+      "nameExplicit": false,
+      "name": "collection_authors_collection_slug_author_slug_pk",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "collection_authors"
+    },
+    {
+      "columns": [
+        "slug",
+        "locale"
+      ],
+      "nameExplicit": false,
+      "name": "collection_data_slug_locale_pk",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "columns": [
+        "post_slug",
+        "author_slug"
+      ],
+      "nameExplicit": false,
+      "name": "post_authors_post_slug_author_slug_pk",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "post_authors"
+    },
+    {
+      "columns": [
+        "slug",
+        "locale",
+        "version"
+      ],
+      "nameExplicit": false,
+      "name": "post_data_slug_locale_version_pk",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "columns": [
+        "gist_id",
+        "filename"
+      ],
+      "nameExplicit": false,
+      "name": "url_metadata_gist_file_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "url_metadata_gist_file"
+    },
+    {
+      "columns": [
+        "collection_slug",
+        "tag"
+      ],
+      "nameExplicit": false,
+      "name": "collection_tags_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "collection_tags"
+    },
+    {
+      "columns": [
+        "post_slug",
+        "tag"
+      ],
+      "nameExplicit": false,
+      "name": "post_tags_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "post_tags"
+    },
+    {
+      "columns": [
+        "post_slug",
+        "attachment_name"
+      ],
+      "nameExplicit": false,
+      "name": "post_attachments_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "post_attachments"
+    },
+    {
+      "columns": [
+        "slug"
+      ],
+      "nameExplicit": false,
+      "name": "profiles_pkey",
+      "schema": "public",
+      "table": "profiles",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "slug"
+      ],
+      "nameExplicit": false,
+      "name": "collections_pkey",
+      "schema": "public",
+      "table": "collections",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "slug"
+      ],
+      "nameExplicit": false,
+      "name": "posts_pkey",
+      "schema": "public",
+      "table": "posts",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "slug"
+      ],
+      "nameExplicit": false,
+      "name": "post_images_pkey",
+      "schema": "public",
+      "table": "post_images",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "url"
+      ],
+      "nameExplicit": false,
+      "name": "url_metadata_pkey",
+      "schema": "public",
+      "table": "url_metadata",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "gist_id"
+      ],
+      "nameExplicit": false,
+      "name": "url_metadata_gist_pkey",
+      "schema": "public",
+      "table": "url_metadata_gist",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "post_id"
+      ],
+      "nameExplicit": false,
+      "name": "url_metadata_post_pkey",
+      "schema": "public",
+      "table": "url_metadata_post",
+      "entityType": "pks"
+    }
+  ],
+  "renames": []
+}

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -4,3 +4,4 @@ export * from "./posts.ts";
 export * from "./post-images.ts";
 export * from "./url-metadata.ts";
 export * from "./tags.ts";
+export * from "./post-attachments.ts";

--- a/packages/db/src/schema/post-attachments.ts
+++ b/packages/db/src/schema/post-attachments.ts
@@ -1,0 +1,22 @@
+import { pgTable, text, integer, primaryKey } from "drizzle-orm/pg-core";
+import { posts } from "./posts.ts";
+
+export const postAttachments = pgTable(
+	"post_attachments",
+	{
+		postSlug: text("post_slug")
+			.notNull()
+			.references(() => posts.slug, {
+				onDelete: "cascade",
+			}),
+		attachmentName: text("attachment_name").notNull(),
+		attachmentKey: text("attachment_key").notNull(),
+		width: integer("width"),
+		height: integer("height"),
+	},
+	(table) => [
+		primaryKey({
+			columns: [table.postSlug, table.attachmentName],
+		}),
+	],
+);

--- a/packages/db/src/schema/post-attachments.ts
+++ b/packages/db/src/schema/post-attachments.ts
@@ -11,6 +11,7 @@ export const postAttachments = pgTable(
 			}),
 		attachmentName: text("attachment_name").notNull(),
 		attachmentKey: text("attachment_key").notNull(),
+		sha: text("sha").notNull(),
 		width: integer("width"),
 		height: integer("height"),
 	},


### PR DESCRIPTION
## Summary

Closes #86.

When a post is synced, any non-markdown files in that post's GitHub folder — images, PDFs, PowerPoints, and files nested in subfolders — are now uploaded to S3 and tracked in a new `post_attachments` table, with cleanup when files are removed from the repo or the post itself is deleted.

This is unrelated to the existing `post_images` table/task, which only covers generated banner and social-share images.

### Schema

- New `post_attachments` table (`packages/db/src/schema/post-attachments.ts`): `postSlug` (FK → `posts.slug`, cascade), `attachmentName`, `attachmentKey`, nullable `width`/`height`. Composite PK on `(postSlug, attachmentName)`, following the `postTags`/`postAuthors` pattern (no synthetic id column).

### sync-post processor

- After the existing markdown-upload phase, a new phase recursively lists everything in the post's base folder (excluding `index*.md` locale files), including nested subfolders.
- Each attachment is fetched via `getContentsRawStream`. Images (by extension) are resized and converted to JPEG, mirroring the approach in `sync-author`'s profile image pipeline. Non-images are uploaded as-is with a small extension→MIME-type map.
- **S3 key naming for images**: since the resize step converts the actual bytes to JPEG, the S3 key extension is normalized to `.jpeg` (e.g. `banner.png` → `posts/{post}/attachments/banner.jpeg`) rather than keeping the original extension, so nothing infers content-type from a mismatched extension. `attachmentName` in the database still stores the original filename exactly as it appeared in the repo. Non-image keys keep their original extension.
- Diffing: previous `post_attachments` rows are compared against the freshly discovered set by `attachmentName`. Missing attachments are deleted from S3. For attachments still present, an MD5 hash of the final (post-resize, if applicable) content is compared against the existing S3 object's ETag (via the already-present but previously-unused `s3.matchesEtag` helper) — unchanged content is skipped, changed content is deleted and re-uploaded under the same key. The full new row set is written to `post_attachments` in the same transaction as the rest of the post's data.
- In the existing 404 branch (post fully removed from the repo), the post's `post_attachments` rows are now fetched and deleted from S3 *before* the `posts` row is deleted, letting the cascading FK handle the database-side cleanup.

### Tests

Added coverage in `sync-post/processor.test.ts` for: new attachment upload (including image resize and subfolder recursion), the diffing behavior (skip-unchanged / delete-and-reupload-changed / remove-deleted), and S3 cleanup in the post-deletion (404) cascade. Also extended `test-utils/setup.ts` with `postAttachments` and `s3.exists`/`s3.matchesEtag` mocks used by these tests.

## Follow-ups (not addressed in this PR)

- **Shared image-resize helper**: this PR adds its own local resize/convert-to-JPEG helper in `sync-post/processor.ts` rather than extracting the logic already duplicated in `sync-author/processor.ts` into a shared utility. Extracting that felt like a bigger refactor than this issue calls for — worth doing as its own follow-up.
- **Pre-existing gap, not introduced by this PR**: the 404 branch (full post removal) still doesn't clean up the post's markdown `content.md` files from S3 for any locale — only the new attachment cleanup was added here. That gap predates this change and is worth its own follow-up.
- **Unhandled stream errors in image resizing**: `resizeAttachmentImage` pipes `Readable.fromWeb(stream)` into the sharp pipeline without explicit error handling on the source stream, so a mid-transfer GitHub fetch failure could surface as an unhandled exception rather than a clean job failure. This same pattern already exists, unfixed, in `sync-author`'s `processProfileImg`, which this code intentionally mirrors — worth fixing in both places together as its own follow-up rather than patching just the new copy here.
- **Architectural note (not implemented here)**: James flagged that this pattern — deleting S3 objects as soon as they're superseded or removed — will eventually cause cache-invalidation problems, since the frontend/CDN won't immediately reflect deletions. He wants to look into S3 lifecycle rules with object tagging instead of immediate deletion. This pattern shows up in a few other places in the codebase too, and is worth a broader look rather than a per-PR fix.

## Test plan

- [X] `pnpm test:unit` passes (lint, knip, publint, sherif, vitest) — confirmed locally
- [X] `pnpm prettier` check passes — confirmed locally
- [X] Manual smoke test: sync a post with a real attachment folder locally against Minio and confirm objects land under `posts/{post}/attachments/...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Post synchronization now supports attachment syncing, persisting attachment metadata (including dimensions) alongside posts.
  * Images are optimized during sync (resize with JPEG conversion when appropriate) before upload to storage.

* **Bug Fixes**
  * Removed or deleted post attachments are cleaned up from storage (including when a post folder no longer exists upstream).
  * Sync now skips re-uploading attachments when content is unchanged, and replaces only modified attachments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->