### PR TITLE
feat(api): add post count and sortBy to GET /content/profiles

### DIFF
--- a/apps/api/src/routes/content/profiles.test.ts
+++ b/apps/api/src/routes/content/profiles.test.ts
@@ -148,10 +148,29 @@ describe("Profiles Routes Tests", () => {
 			});
 
 			expect(response.statusCode).toBe(200);
-			expect(chain.orderBy).toBeCalledWith(desc(countDistinct(postData.slug)));
+			expect(chain.orderBy).toBeCalledWith(
+				desc(countDistinct(postData.slug)),
+				asc(profiles.slug),
+			);
 			expect(
 				response.json().map((profile: { id: string }) => profile.id),
 			).toEqual(["crutchcorn", "fennifith"]);
+		});
+
+		test("joins postAuthors on the profile's slug", async () => {
+			const chain = mockSelectChain([]);
+
+			const response = await app.inject({
+				method: "GET",
+				url: "/content/profiles",
+				query: { page: "0", limit: "10" },
+			});
+
+			expect(response.statusCode).toBe(200);
+			expect(chain.leftJoinPostAuthors).toBeCalledWith(
+				postAuthors,
+				eq(postAuthors.authorSlug, profiles.slug),
+			);
 		});
 
 		test("only counts posts with a publishedAt date and noindex false", async () => {

--- a/apps/api/src/routes/content/profiles.test.ts
+++ b/apps/api/src/routes/content/profiles.test.ts
@@ -1,6 +1,31 @@
 import fastify, { type FastifyInstance } from "fastify";
 import profilesRoutes from "./profiles.ts";
-import { db } from "@playfulprogramming/db";
+import { db, profiles, postAuthors, postData } from "@playfulprogramming/db";
+import { and, asc, countDistinct, desc, eq, isNotNull } from "drizzle-orm";
+
+function mockSelectChain(rows: unknown[]) {
+	const offset = vi.fn().mockResolvedValue(rows);
+	const limit = vi.fn().mockReturnValue({ offset });
+	const orderBy = vi.fn().mockReturnValue({ limit });
+	const groupBy = vi.fn().mockReturnValue({ orderBy });
+	const leftJoinPostData = vi.fn().mockReturnValue({ groupBy });
+	const leftJoinPostAuthors = vi
+		.fn()
+		.mockReturnValue({ leftJoin: leftJoinPostData });
+	const from = vi.fn().mockReturnValue({ leftJoin: leftJoinPostAuthors });
+
+	vi.mocked(db.select).mockReturnValue({ from } as never);
+
+	return {
+		from,
+		leftJoinPostAuthors,
+		leftJoinPostData,
+		groupBy,
+		orderBy,
+		limit,
+		offset,
+	};
+}
 
 describe("Profiles Routes Tests", () => {
 	let app: FastifyInstance;
@@ -15,20 +40,22 @@ describe("Profiles Routes Tests", () => {
 
 	describe("/content/profiles", () => {
 		test("returns all profiles", async () => {
-			vi.mocked(db.query.profiles.findMany).mockResolvedValue([
+			mockSelectChain([
 				{
 					slug: "crutchcorn",
 					name: "Corbin Crutchley",
 					description: "Project lead for Playful Programming.",
 					profileImage: "content/profile.png",
+					postsCount: 3,
 				},
 				{
 					slug: "fennifith",
 					name: "James Fenn",
 					description: "Backend lead for Playful Programming.",
 					profileImage: null,
+					postsCount: 0,
 				},
-			] as never);
+			]);
 
 			const response = await app.inject({
 				method: "GET",
@@ -43,19 +70,21 @@ describe("Profiles Routes Tests", () => {
 				    "description": "Project lead for Playful Programming.",
 				    "id": "crutchcorn",
 				    "name": "Corbin Crutchley",
+				    "posts": 3,
 				    "profileImageUrl": "https://s3_public_url.test/s3_bucket/content/profile.png",
 				  },
 				  {
 				    "description": "Backend lead for Playful Programming.",
 				    "id": "fennifith",
 				    "name": "James Fenn",
+				    "posts": 0,
 				  },
 				]
 			`);
 		});
 
 		test("returns an empty list when there are no profiles", async () => {
-			vi.mocked(db.query.profiles.findMany).mockResolvedValue([]);
+			mockSelectChain([]);
 
 			const response = await app.inject({
 				method: "GET",
@@ -68,7 +97,7 @@ describe("Profiles Routes Tests", () => {
 		});
 
 		test("paginates using page and limit query params", async () => {
-			vi.mocked(db.query.profiles.findMany).mockResolvedValue([]);
+			const chain = mockSelectChain([]);
 
 			const response = await app.inject({
 				method: "GET",
@@ -77,11 +106,71 @@ describe("Profiles Routes Tests", () => {
 			});
 
 			expect(response.statusCode).toBe(200);
-			expect(db.query.profiles.findMany).toBeCalledWith(
-				expect.objectContaining({
-					offset: 20,
-					limit: 10,
-				}),
+			expect(chain.limit).toBeCalledWith(10);
+			expect(chain.offset).toBeCalledWith(20);
+		});
+
+		test("defaults to sortBy=id, ordering by profile slug ascending", async () => {
+			const chain = mockSelectChain([]);
+
+			const response = await app.inject({
+				method: "GET",
+				url: "/content/profiles",
+				query: { page: "0", limit: "10" },
+			});
+
+			expect(response.statusCode).toBe(200);
+			expect(chain.orderBy).toBeCalledWith(asc(profiles.slug));
+		});
+
+		test("sortBy=posts orders authors by descending post count", async () => {
+			const chain = mockSelectChain([
+				{
+					slug: "crutchcorn",
+					name: "Corbin Crutchley",
+					description: "Project lead for Playful Programming.",
+					profileImage: null,
+					postsCount: 10,
+				},
+				{
+					slug: "fennifith",
+					name: "James Fenn",
+					description: "Backend lead for Playful Programming.",
+					profileImage: null,
+					postsCount: 4,
+				},
+			]);
+
+			const response = await app.inject({
+				method: "GET",
+				url: "/content/profiles",
+				query: { page: "0", limit: "10", sortBy: "posts" },
+			});
+
+			expect(response.statusCode).toBe(200);
+			expect(chain.orderBy).toBeCalledWith(desc(countDistinct(postData.slug)));
+			expect(
+				response.json().map((profile: { id: string }) => profile.id),
+			).toEqual(["crutchcorn", "fennifith"]);
+		});
+
+		test("only counts posts with a publishedAt date and noindex false", async () => {
+			const chain = mockSelectChain([]);
+
+			const response = await app.inject({
+				method: "GET",
+				url: "/content/profiles",
+				query: { page: "0", limit: "10" },
+			});
+
+			expect(response.statusCode).toBe(200);
+			expect(chain.leftJoinPostData).toBeCalledWith(
+				postData,
+				and(
+					eq(postData.slug, postAuthors.postSlug),
+					isNotNull(postData.publishedAt),
+					eq(postData.noindex, false),
+				),
 			);
 		});
 	});

--- a/apps/api/src/routes/content/profiles.ts
+++ b/apps/api/src/routes/content/profiles.ts
@@ -95,9 +95,9 @@ const profilesRoutes: FastifyPluginAsync = async (fastify) => {
 					profiles.profileImage,
 				)
 				.orderBy(
-					sortBy === "posts"
-						? desc(countDistinct(postData.slug))
-						: asc(profiles.slug),
+					...(sortBy === "posts"
+						? [desc(countDistinct(postData.slug)), asc(profiles.slug)]
+						: [asc(profiles.slug)]),
 				)
 				.limit(queryParams.limit)
 				.offset(queryParams.page * queryParams.limit);

--- a/apps/api/src/routes/content/profiles.ts
+++ b/apps/api/src/routes/content/profiles.ts
@@ -1,11 +1,15 @@
 import type { FastifyPluginAsync } from "fastify";
-import { db } from "@playfulprogramming/db";
+import { db, profiles, postAuthors, postData } from "@playfulprogramming/db";
+import { and, asc, countDistinct, desc, eq, isNotNull } from "drizzle-orm";
 import { Type, type Static } from "typebox";
 import { createImageUrl } from "../../utils.ts";
 
 const ProfilesQueryParamsSchema = Type.Object({
 	page: Type.Number({ minimum: 0 }),
 	limit: Type.Number({ minimum: 1 }),
+	sortBy: Type.Union([Type.Literal("id"), Type.Literal("posts")], {
+		default: "id",
+	}),
 });
 
 const ProfilesResponseSchema = Type.Array(
@@ -15,6 +19,7 @@ const ProfilesResponseSchema = Type.Array(
 			name: Type.String(),
 			description: Type.String(),
 			profileImageUrl: Type.Optional(Type.String()),
+			posts: Type.Number(),
 		},
 		{
 			examples: [
@@ -23,12 +28,14 @@ const ProfilesResponseSchema = Type.Array(
 					name: "Corbin Crutchley",
 					description: "Project lead for Playful Programming.",
 					profileImageUrl: "https://example.test/profile.jpg",
+					posts: 12,
 				},
 				{
 					id: "fennifith",
 					name: "James Fenn",
 					description: "Backend lead for Playful Programming.",
 					profileImageUrl: "https://example.test/profile.jpg",
+					posts: 8,
 				},
 			],
 		},
@@ -61,25 +68,48 @@ const profilesRoutes: FastifyPluginAsync = async (fastify) => {
 		},
 		async (request, reply) => {
 			const queryParams = request.query;
+			const { sortBy } = queryParams;
 
-			const profiles = await db.query.profiles.findMany({
-				columns: {
-					slug: true,
-					name: true,
-					description: true,
-					profileImage: true,
-				},
-				offset: queryParams.page * queryParams.limit,
-				limit: queryParams.limit,
-			});
+			const profileRows = await db
+				.select({
+					slug: profiles.slug,
+					name: profiles.name,
+					description: profiles.description,
+					profileImage: profiles.profileImage,
+					postsCount: countDistinct(postData.slug),
+				})
+				.from(profiles)
+				.leftJoin(postAuthors, eq(postAuthors.authorSlug, profiles.slug))
+				.leftJoin(
+					postData,
+					and(
+						eq(postData.slug, postAuthors.postSlug),
+						isNotNull(postData.publishedAt),
+						eq(postData.noindex, false),
+					),
+				)
+				.groupBy(
+					profiles.slug,
+					profiles.name,
+					profiles.description,
+					profiles.profileImage,
+				)
+				.orderBy(
+					sortBy === "posts"
+						? desc(countDistinct(postData.slug))
+						: asc(profiles.slug),
+				)
+				.limit(queryParams.limit)
+				.offset(queryParams.page * queryParams.limit);
 
-			const profilesResponse: ProfilesResponse = profiles.map((profile) => ({
+			const profilesResponse: ProfilesResponse = profileRows.map((profile) => ({
 				id: profile.slug,
 				name: profile.name,
 				description: profile.description,
 				profileImageUrl: profile.profileImage
 					? createImageUrl(profile.profileImage)
 					: undefined,
+				posts: profile.postsCount,
 			}));
 
 			reply.code(200);

--- a/apps/api/test-utils/setup.ts
+++ b/apps/api/test-utils/setup.ts
@@ -21,6 +21,21 @@ vi.mock("@playfulprogramming/redis", () => {
 
 vi.mock("@playfulprogramming/db", () => {
 	return {
+		profiles: {
+			slug: {},
+			name: {},
+			description: {},
+			profileImage: {},
+		},
+		postAuthors: {
+			postSlug: {},
+			authorSlug: {},
+		},
+		postData: {
+			slug: {},
+			publishedAt: {},
+			noindex: {},
+		},
 		db: {
 			query: {
 				postImages: {
@@ -39,6 +54,7 @@ vi.mock("@playfulprogramming/db", () => {
 					findMany: vi.fn(),
 				},
 			},
+			select: vi.fn(),
 		},
 	};
 });


### PR DESCRIPTION
## Summary

Closes #176.

Extends `GET /content/profiles` with a `posts` count per author and a `sortBy` query param (`id` | `posts`), so the Search page can render a "top N authors by post count" list.

- Switched the route from `db.query.profiles.findMany` (relational query API) to `db.select` (core query builder), since ordering by an aggregated to-many count while paginating correctly isn't supported by the relational API.
- `profiles` → left join `postAuthors` → left join `postData`, filtered to `publishedAt is not null` and `noindex = false` in the join condition (same draft-post visibility convention as #80's `/content/post/:slug` endpoint), grouped by profile, with `countDistinct(postData.slug)` as the post count. `postData` is keyed per locale/version, so `countDistinct` avoids double-counting a post published in multiple locales.
- `sortBy` defaults to `id` (existing behavior: `profiles.slug` ascending, unchanged) or `posts` (post count descending, most active authors first).
- Added `posts` as a required field on the response schema, with updated example payloads.

Note: the issue text described joining `postAuthors` to `posts` and filtering `posts` by `publishedAt`/`noindex` — but those columns actually live on `postData`, not `posts`, so the query joins `postData` directly (skipping an unnecessary extra hop through `posts`, since `postAuthors.postSlug` already FK-references `posts.slug`).

## Test plan

- [x] `pnpm test:unit` (lint, knip, publint, sherif, vitest across all NX projects)
- [x] `pnpm prettier` (check mode)
- [x] Extended `profiles.test.ts`: default `sortBy=id` unchanged, `sortBy=posts` ordering, and posts without a `publishedAt` or with `noindex: true` excluded from the count (verified via the join's filter predicate, since the DB layer is mocked in this test suite)
- [x] Also updated the shared `apps/api/test-utils/setup.ts` `@playfulprogramming/db` mock to expose `profiles`/`postAuthors`/`postData` table placeholders and `db.select`, needed for the new query builder usage (existing tests for other routes unaffected — all 29 API tests pass)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Profiles can now be sorted using a query option, including sorting by post count.
  * Profile responses now include a post count for each profile.

* **Bug Fixes**
  * Improved profile listing to better reflect published, indexable posts.
  * Profile image URLs continue to be returned consistently when available.

* **Tests**
  * Expanded coverage for sorting, pagination, joins, and response shape changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->