### PR TITLE
feat: add author_roles table, sync from author frontmatter (#177)

### DIFF
--- a/apps/worker/src/tasks/sync-author/processor.test.ts
+++ b/apps/worker/src/tasks/sync-author/processor.test.ts
@@ -1,18 +1,31 @@
 import processor from "./processor.ts";
 import type { TaskInputs } from "@playfulprogramming/bullmq";
 import type { Job } from "bullmq";
-import { db, profiles } from "@playfulprogramming/db";
+import { db, profiles, authorRoles } from "@playfulprogramming/db";
 import { s3 } from "@playfulprogramming/s3";
 import * as github from "@playfulprogramming/github-api";
 import { Readable } from "node:stream";
 import { eq } from "drizzle-orm";
 
 test("Creates an example profile successfully", async () => {
-	const insertValues = vi.fn().mockReturnValue({
+	const insertProfilesValues = vi.fn().mockReturnValue({
 		onConflictDoUpdate: vi.fn(),
 	});
-	vi.mocked(db.insert).mockReturnValue({
-		values: insertValues,
+	const insertAuthorRolesValues = vi.fn();
+
+	vi.mocked(db.insert).mockImplementation((table) => {
+		if (table === profiles) {
+			return { values: insertProfilesValues } as never;
+		}
+		if (table === authorRoles) {
+			return { values: insertAuthorRolesValues } as never;
+		}
+		throw new Error(`Unexpected table: ${table}`);
+	});
+
+	const deleteWhere = vi.fn();
+	vi.mocked(db.delete).mockReturnValue({
+		where: deleteWhere,
 	} as never);
 
 	vi.mocked(github.getContentsRaw).mockImplementation((params) => {
@@ -22,7 +35,8 @@ test("Creates an example profile successfully", async () => {
 {
   name: "Example Person",
   description: "Hello",
-  profileImg: "./profile.png"
+  profileImg: "./profile.png",
+  roles: ["author", "editor"]
 }
 ---
 `,
@@ -62,17 +76,153 @@ test("Creates an example profile successfully", async () => {
 		"image/jpeg",
 	);
 
-	// The profile was inserted into the database
-	expect(insertValues).toBeCalledWith({
+	// The profile was inserted into the database, without roles in meta
+	expect(insertProfilesValues).toBeCalledWith({
 		slug: "example",
 		name: "Example Person",
 		description: "Hello",
 		profileImage: "profiles/example.jpeg",
 		meta: {
 			socials: {},
-			roles: [],
 		},
 	});
+
+	// Old roles were deleted, new roles were inserted
+	expect(deleteWhere).toBeCalledWith(eq(authorRoles.profileSlug, "example"));
+	expect(insertAuthorRolesValues).toBeCalledWith([
+		{ profileSlug: "example", role: "author" },
+		{ profileSlug: "example", role: "editor" },
+	]);
+});
+
+test("Replaces an existing author's roles on a subsequent sync with a different role set", async () => {
+	const insertProfilesValues = vi.fn().mockReturnValue({
+		onConflictDoUpdate: vi.fn(),
+	});
+	const insertAuthorRolesValues = vi.fn();
+
+	vi.mocked(db.insert).mockImplementation((table) => {
+		if (table === profiles) {
+			return { values: insertProfilesValues } as never;
+		}
+		if (table === authorRoles) {
+			return { values: insertAuthorRolesValues } as never;
+		}
+		throw new Error(`Unexpected table: ${table}`);
+	});
+
+	const deleteWhere = vi.fn();
+	vi.mocked(db.delete).mockReturnValue({
+		where: deleteWhere,
+	} as never);
+
+	vi.mocked(github.getContentsRaw).mockImplementationOnce((params) => {
+		if (params.path === "/content/example/index.md") {
+			return Promise.resolve({
+				data: `---
+{
+  name: "Example Person",
+  description: "Hello",
+  roles: ["author"]
+}
+---
+`,
+				status: 200,
+			});
+		}
+		return Promise.reject();
+	});
+
+	await processor({
+		data: {
+			author: "example",
+			ref: "main",
+		},
+	} as unknown as Job<TaskInputs["sync-author"]>);
+
+	expect(insertAuthorRolesValues).toBeCalledWith([
+		{ profileSlug: "example", role: "author" },
+	]);
+
+	vi.mocked(github.getContentsRaw).mockImplementationOnce((params) => {
+		if (params.path === "/content/example/index.md") {
+			return Promise.resolve({
+				data: `---
+{
+  name: "Example Person",
+  description: "Hello",
+  roles: ["editor", "reviewer"]
+}
+---
+`,
+				status: 200,
+			});
+		}
+		return Promise.reject();
+	});
+
+	await processor({
+		data: {
+			author: "example",
+			ref: "main",
+		},
+	} as unknown as Job<TaskInputs["sync-author"]>);
+
+	// Old roles were deleted again, and only the new role set was inserted
+	expect(deleteWhere).toBeCalledWith(eq(authorRoles.profileSlug, "example"));
+	expect(insertAuthorRolesValues).toHaveBeenLastCalledWith([
+		{ profileSlug: "example", role: "editor" },
+		{ profileSlug: "example", role: "reviewer" },
+	]);
+});
+
+test("Inserts no rows for an author with an empty roles array", async () => {
+	const insertProfilesValues = vi.fn().mockReturnValue({
+		onConflictDoUpdate: vi.fn(),
+	});
+	const insertAuthorRolesValues = vi.fn();
+
+	vi.mocked(db.insert).mockImplementation((table) => {
+		if (table === profiles) {
+			return { values: insertProfilesValues } as never;
+		}
+		if (table === authorRoles) {
+			return { values: insertAuthorRolesValues } as never;
+		}
+		throw new Error(`Unexpected table: ${table}`);
+	});
+
+	const deleteWhere = vi.fn();
+	vi.mocked(db.delete).mockReturnValue({
+		where: deleteWhere,
+	} as never);
+
+	vi.mocked(github.getContentsRaw).mockImplementation((params) => {
+		if (params.path === "/content/example/index.md") {
+			return Promise.resolve({
+				data: `---
+{
+  name: "Example Person",
+  description: "Hello"
+}
+---
+`,
+				status: 200,
+			});
+		}
+		return Promise.reject();
+	});
+
+	await processor({
+		data: {
+			author: "example",
+			ref: "main",
+		},
+	} as unknown as Job<TaskInputs["sync-author"]>);
+
+	// Roles were still deleted (in case any existed previously), but nothing was inserted
+	expect(deleteWhere).toBeCalledWith(eq(authorRoles.profileSlug, "example"));
+	expect(insertAuthorRolesValues).not.toBeCalled();
 });
 
 test("Deletes a profile record if it no longer exists", async () => {

--- a/apps/worker/src/tasks/sync-author/processor.ts
+++ b/apps/worker/src/tasks/sync-author/processor.ts
@@ -1,6 +1,11 @@
 import { env } from "@playfulprogramming/common";
 import { Tasks, createJob } from "@playfulprogramming/bullmq";
-import { db, profiles, profileAchievements } from "@playfulprogramming/db";
+import {
+	db,
+	profiles,
+	profileAchievements,
+	authorRoles,
+} from "@playfulprogramming/db";
 import * as github from "@playfulprogramming/github-api";
 import { s3 } from "@playfulprogramming/s3";
 import { createProcessor } from "../../createProcessor.ts";
@@ -90,7 +95,6 @@ export default createProcessor(Tasks.SYNC_AUTHOR, async (job, { signal }) => {
 		profileImage: profileImgKey,
 		meta: {
 			socials: authorData.socials,
-			roles: authorData.roles,
 		},
 	};
 
@@ -122,6 +126,17 @@ export default createProcessor(Tasks.SYNC_AUTHOR, async (job, { signal }) => {
 				earnedManualIds.map((achievementId) => ({
 					profileSlug: authorId,
 					achievementId,
+				})),
+			);
+		}
+
+		await tx.delete(authorRoles).where(eq(authorRoles.profileSlug, authorId));
+
+		if (authorData.roles.length > 0) {
+			await tx.insert(authorRoles).values(
+				authorData.roles.map((role) => ({
+					profileSlug: authorId,
+					role,
 				})),
 			);
 		}

--- a/apps/worker/src/tasks/sync-author/processor.ts
+++ b/apps/worker/src/tasks/sync-author/processor.ts
@@ -31,7 +31,9 @@ async function processProfileImg(
 		})
 		.jpeg({ mozjpeg: true });
 
-	Readable.fromWeb(stream as never).pipe(pipeline);
+	const source = Readable.fromWeb(stream as never);
+	source.on("error", (err) => pipeline.destroy(err));
+	source.pipe(pipeline);
 
 	const bucket = await s3.ensureBucket(env.S3_BUCKET);
 	await s3.upload(bucket, uploadKey, undefined, pipeline, "image/jpeg");

--- a/apps/worker/test-utils/setup.ts
+++ b/apps/worker/test-utils/setup.ts
@@ -63,6 +63,10 @@ vi.mock("@playfulprogramming/db", () => {
 			profileSlug: {},
 			achievementId: {},
 		},
+		authorRoles: {
+			profileSlug: {},
+			role: {},
+		},
 		posts: {
 			slug: {},
 		},

--- a/packages/db/drizzle/20260709150348_shocking_expediter/migration.sql
+++ b/packages/db/drizzle/20260709150348_shocking_expediter/migration.sql
@@ -1,0 +1,7 @@
+CREATE TABLE "author_roles" (
+	"profile_slug" text,
+	"role" text,
+	CONSTRAINT "author_roles_pkey" PRIMARY KEY("profile_slug","role")
+);
+--> statement-breakpoint
+ALTER TABLE "author_roles" ADD CONSTRAINT "author_roles_profile_slug_profiles_slug_fkey" FOREIGN KEY ("profile_slug") REFERENCES "profiles"("slug") ON DELETE CASCADE;

--- a/packages/db/drizzle/20260709150348_shocking_expediter/snapshot.json
+++ b/packages/db/drizzle/20260709150348_shocking_expediter/snapshot.json
@@ -1,0 +1,1673 @@
+{
+  "version": "8",
+  "dialect": "postgres",
+  "id": "6e896762-9a78-46e0-b1dc-5fc6e15aa2ea",
+  "prevIds": [
+    "a9cd32a6-e23f-4121-bc8f-6d4282e95a3c",
+    "e66fa34b-90bc-4916-a2b3-3c783ad69266"
+  ],
+  "ddl": [
+    {
+      "isRlsEnabled": false,
+      "name": "author_roles",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "profile_achievements",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "profiles",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "collection_authors",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "collection_data",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "collections",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "post_authors",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "post_data",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "posts",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "post_images",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "url_metadata",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "url_metadata_gist",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "url_metadata_gist_file",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "url_metadata_post",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "collection_tags",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "post_tags",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "profile_slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "author_roles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "role",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "author_roles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "profile_slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_achievements"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "achievement_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_achievements"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "granted_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profile_achievements"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "''",
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "profile_image",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profiles"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "published_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profiles"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "meta",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "profiles"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "collection_slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_authors"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "author_slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_authors"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "locale",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "''",
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "published_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "meta",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "cover_image",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "social_image",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collections"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "post_slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_authors"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "author_slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_authors"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "locale",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "''",
+      "generated": null,
+      "identity": null,
+      "name": "version",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "''",
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "word_count",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "social_image",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "banner_image",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "original_link",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "noindex",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "edited_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "published_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "meta",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "collection_slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "collection_order",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_images"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "banner_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_images"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "link_preview_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_images"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "index_md5",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_images"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "fetched_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_images"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "error",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_images"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "url",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "title",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "icon_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "icon_width",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "icon_height",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "banner_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "banner_width",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "banner_height",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "gist_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "post_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "embed_src",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "embed_width",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "embed_height",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "embed_type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "fetched_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "error",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "gist_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_gist"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "username",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_gist"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_gist"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "gist_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_gist_file"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "filename",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_gist_file"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "content_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_gist_file"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "language",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_gist_file"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "post_id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "author_name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "author_handle",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "content",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "url",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "avatar_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "avatar_width",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "avatar_height",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image_key",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image_width",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image_height",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "varchar(2048)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image_alt_text",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "num_likes",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "num_reposts",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "num_replies",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "url_metadata_post"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "collection_slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_tags"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "tag",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "collection_tags"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "post_slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_tags"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "tag",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "post_tags"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "profile_slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "profiles",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "author_roles_profile_slug_profiles_slug_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "author_roles"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "profile_slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "profiles",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "profile_achievements_profile_slug_profiles_slug_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "profile_achievements"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "collection_slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "collections",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "collection_authors_collection_slug_collections_slug_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "collection_authors"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "author_slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "profiles",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "collection_authors_author_slug_profiles_slug_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "collection_authors"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "collections",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "collection_data_slug_collections_slug_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "post_slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "posts",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "post_authors_post_slug_posts_slug_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "post_authors"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "author_slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "profiles",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "post_authors_author_slug_profiles_slug_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "post_authors"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "posts",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "post_data_slug_posts_slug_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "collection_slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "collections",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "name": "posts_collection_slug_collections_slug_fk",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "posts"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "gist_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "url_metadata_gist",
+      "columnsTo": [
+        "gist_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "name": "url_metadata_gist_id_url_metadata_gist_gist_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "post_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "url_metadata_post",
+      "columnsTo": [
+        "post_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "name": "url_metadata_post_id_url_metadata_post_post_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "url_metadata"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "gist_id"
+      ],
+      "schemaTo": "public",
+      "tableTo": "url_metadata_gist",
+      "columnsTo": [
+        "gist_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "url_metadata_gist_file_gist_id_url_metadata_gist_gist_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "url_metadata_gist_file"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "collection_slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "collections",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "collection_tags_collection_slug_collections_slug_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "collection_tags"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "post_slug"
+      ],
+      "schemaTo": "public",
+      "tableTo": "posts",
+      "columnsTo": [
+        "slug"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "post_tags_post_slug_posts_slug_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "post_tags"
+    },
+    {
+      "columns": [
+        "profile_slug",
+        "role"
+      ],
+      "nameExplicit": false,
+      "name": "author_roles_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "author_roles"
+    },
+    {
+      "columns": [
+        "profile_slug",
+        "achievement_id"
+      ],
+      "nameExplicit": false,
+      "name": "profile_achievements_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "profile_achievements"
+    },
+    {
+      "columns": [
+        "collection_slug",
+        "author_slug"
+      ],
+      "nameExplicit": false,
+      "name": "collection_authors_collection_slug_author_slug_pk",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "collection_authors"
+    },
+    {
+      "columns": [
+        "slug",
+        "locale"
+      ],
+      "nameExplicit": false,
+      "name": "collection_data_slug_locale_pk",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "collection_data"
+    },
+    {
+      "columns": [
+        "post_slug",
+        "author_slug"
+      ],
+      "nameExplicit": false,
+      "name": "post_authors_post_slug_author_slug_pk",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "post_authors"
+    },
+    {
+      "columns": [
+        "slug",
+        "locale",
+        "version"
+      ],
+      "nameExplicit": false,
+      "name": "post_data_slug_locale_version_pk",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "post_data"
+    },
+    {
+      "columns": [
+        "gist_id",
+        "filename"
+      ],
+      "nameExplicit": false,
+      "name": "url_metadata_gist_file_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "url_metadata_gist_file"
+    },
+    {
+      "columns": [
+        "collection_slug",
+        "tag"
+      ],
+      "nameExplicit": false,
+      "name": "collection_tags_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "collection_tags"
+    },
+    {
+      "columns": [
+        "post_slug",
+        "tag"
+      ],
+      "nameExplicit": false,
+      "name": "post_tags_pkey",
+      "entityType": "pks",
+      "schema": "public",
+      "table": "post_tags"
+    },
+    {
+      "columns": [
+        "slug"
+      ],
+      "nameExplicit": false,
+      "name": "profiles_pkey",
+      "schema": "public",
+      "table": "profiles",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "slug"
+      ],
+      "nameExplicit": false,
+      "name": "collections_pkey",
+      "schema": "public",
+      "table": "collections",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "slug"
+      ],
+      "nameExplicit": false,
+      "name": "posts_pkey",
+      "schema": "public",
+      "table": "posts",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "slug"
+      ],
+      "nameExplicit": false,
+      "name": "post_images_pkey",
+      "schema": "public",
+      "table": "post_images",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "url"
+      ],
+      "nameExplicit": false,
+      "name": "url_metadata_pkey",
+      "schema": "public",
+      "table": "url_metadata",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "gist_id"
+      ],
+      "nameExplicit": false,
+      "name": "url_metadata_gist_pkey",
+      "schema": "public",
+      "table": "url_metadata_gist",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "post_id"
+      ],
+      "nameExplicit": false,
+      "name": "url_metadata_post_pkey",
+      "schema": "public",
+      "table": "url_metadata_post",
+      "entityType": "pks"
+    }
+  ],
+  "renames": []
+}

--- a/packages/db/src/schema/profiles.ts
+++ b/packages/db/src/schema/profiles.ts
@@ -33,9 +33,6 @@ export const profileAchievements = pgTable(
 	],
 );
 
-// Placed here for now since it's an owner-scoped role list like profileAchievements,
-// but it's structurally identical to the post_tags/collection_tags (ownerSlug, value)
-// composite-PK pattern in tags.ts, so this may belong there instead — open question for James.
 export const authorRoles = pgTable(
 	"author_roles",
 	{

--- a/packages/db/src/schema/profiles.ts
+++ b/packages/db/src/schema/profiles.ts
@@ -32,3 +32,17 @@ export const profileAchievements = pgTable(
 		primaryKey({ columns: [table.profileSlug, table.achievementId] }),
 	],
 );
+
+// Placed here for now since it's an owner-scoped role list like profileAchievements,
+// but it's structurally identical to the post_tags/collection_tags (ownerSlug, value)
+// composite-PK pattern in tags.ts, so this may belong there instead — open question for James.
+export const authorRoles = pgTable(
+	"author_roles",
+	{
+		profileSlug: text("profile_slug")
+			.notNull()
+			.references(() => profiles.slug, { onDelete: "cascade" }),
+		role: text("role").notNull(),
+	},
+	(table) => [primaryKey({ columns: [table.profileSlug, table.role] })],
+);


### PR DESCRIPTION
## Summary

Closes #177. Adds an `author_roles` table populated from `sync-author`, tracking author roles in a real table instead of `profiles.meta.roles`, so `/content/profiles` can eventually filter by role. This follows the same JSONB-to-join-table pattern as #81's `post_tags`/`collection_tags` work.

- New `author_roles` table: composite PK on `(profileSlug, role)`, FK to `profiles.slug` with cascade delete, no surrogate id — mirroring the shape of `post_tags`/`collection_tags`.
- `sync-author`'s processor now deletes all existing `author_roles` rows for the profile slug and re-inserts the current roles (if any) inside the existing `db.transaction` block, following the same delete-then-insert pattern `sync-post` uses for `postTags`. Authors aren't locale-scoped like posts, so there's no multi-locale aggregation concern here.
- `profiles.meta` no longer includes `roles` — it now only contains `socials`. `GET /content/profiles` doesn't read `meta.roles` anywhere in this repo today, and since `sync-author` does a full `onConflictDoUpdate` on the whole `meta` object every sync, old `meta.roles` data on existing rows will self-heal away automatically the next time each profile is synced. No backfill needed.
- Migration generated via `drizzle-kit generate`.

## Open question: table placement

I placed `author_roles` in `profiles.ts` (alongside the existing `profileAchievements` table) rather than in `tags.ts`, since it's an owner-scoped role list similar to `profileAchievements`. That said, it's structurally identical to the `post_tags`/`collection_tags` `(ownerSlug, value)` composite-PK pattern in `tags.ts` — so James may prefer it live there instead for consistency. Left a comment in the code noting this; happy to move it if that's the preferred convention.

## Heads up for James

`meta.roles` is no longer populated going forward. Nothing in this repo's API currently reads it, so this isn't blocking — but if the frontend repo reads raw profile `meta` directly anywhere, it would need to switch to the new `author_roles` table.

## Test plan

- [x] Extended `apps/worker/src/tasks/sync-author/processor.test.ts`:
  - roles written to `author_roles` on sync
  - existing author's roles fully replaced on a subsequent sync with a different role set
  - empty roles array results in no rows inserted
- [x] `pnpm test:unit` passes (lint, knip, publint, sherif, vitest across all NX projects)

Paste that into the compare URL, double-check for truncation, then create the PR yourself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Author profiles now support a separate list of roles, which is kept up to date during sync.
  * Profile images are now resized and stored automatically in a consistent JPEG format.

* **Bug Fixes**
  * Improved role syncing so old roles are removed before new ones are saved.
  * Empty role lists are handled cleanly without creating extra entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->